### PR TITLE
added omitempty in properties and required

### DIFF
--- a/components/definition/definition.go
+++ b/components/definition/definition.go
@@ -13,8 +13,8 @@ import (
 // See: https://swagger.io/specification/v2/#definitionsObject
 type Definition struct {
 	Type       string                          `json:"type"`
-	Properties map[string]DefinitionProperties `json:"properties"`
-	Required   []string                        `json:"required"`
+	Properties map[string]DefinitionProperties `json:"properties,omitempty"`
+	Required   []string                        `json:"required,omitempty"`
 }
 
 // DefinitionProperties defines the details of a property within a Definition,


### PR DESCRIPTION
Added omitempty because without these it generated a non-compliant OAS 2.0.

`
    "rest.EmptyBody": {
      "type": "object",
      "properties": {},
      "required": []
    },
`
As per OAS 2.0, the properties must have at lease 1 item in properties and required.
My rest.EmptyBody is a 
`
type EmptyBody struct{}
`

Also without the omit, some extra definition are created such as:
`
    "string": {
      "type": "object",
      "properties": {},
      "required": []
  `
  Once I added the omit, my doc.json became compliant 2.0.