### PR TITLE
feature: add support for spec extensions

### DIFF
--- a/v3/components/definition/definition.go
+++ b/v3/components/definition/definition.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/go-swagno/swagno/v3/components/extensions"
 	"github.com/go-swagno/swagno/v3/components/fields"
 	"github.com/go-swagno/swagno/v3/components/http/response"
 )
@@ -50,6 +51,12 @@ type Schema struct {
 	ExternalDocs         *ExternalDocs             `json:"externalDocs,omitempty"`
 	Deprecated           bool                      `json:"deprecated,omitempty"`
 	Ref                  string                    `json:"$ref,omitempty"`
+	Extensions           extensions.Extensions     `json:"-"`
+}
+
+func (s Schema) MarshalJSON() ([]byte, error) {
+	type alias Schema
+	return extensions.Merge(alias(s), s.Extensions)
 }
 
 // SchemaProperty defines the details of a property within a Schema,
@@ -93,23 +100,41 @@ type SchemaItems struct {
 
 // Discriminator represents a discriminator object for polymorphism
 type Discriminator struct {
-	PropertyName string            `json:"propertyName"`
-	Mapping      map[string]string `json:"mapping,omitempty"`
+	PropertyName string                `json:"propertyName"`
+	Mapping      map[string]string     `json:"mapping,omitempty"`
+	Extensions   extensions.Extensions `json:"-"`
+}
+
+func (d Discriminator) MarshalJSON() ([]byte, error) {
+	type alias Discriminator
+	return extensions.Merge(alias(d), d.Extensions)
 }
 
 // XML represents XML metadata
 type XML struct {
-	Name      string `json:"name,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
-	Prefix    string `json:"prefix,omitempty"`
-	Attribute bool   `json:"attribute,omitempty"`
-	Wrapped   bool   `json:"wrapped,omitempty"`
+	Name       string                `json:"name,omitempty"`
+	Namespace  string                `json:"namespace,omitempty"`
+	Prefix     string                `json:"prefix,omitempty"`
+	Attribute  bool                  `json:"attribute,omitempty"`
+	Wrapped    bool                  `json:"wrapped,omitempty"`
+	Extensions extensions.Extensions `json:"-"`
+}
+
+func (x XML) MarshalJSON() ([]byte, error) {
+	type alias XML
+	return extensions.Merge(alias(x), x.Extensions)
 }
 
 // ExternalDocs represents external documentation
 type ExternalDocs struct {
-	Description string `json:"description,omitempty"`
-	URL         string `json:"url"`
+	Description string                `json:"description,omitempty"`
+	URL         string                `json:"url"`
+	Extensions  extensions.Extensions `json:"-"`
+}
+
+func (ed ExternalDocs) MarshalJSON() ([]byte, error) {
+	type alias ExternalDocs
+	return extensions.Merge(alias(ed), ed.Extensions)
 }
 
 // DefinitionGenerator holds a map of Schema objects and is capable

--- a/v3/components/endpoint/endpoints.go
+++ b/v3/components/endpoint/endpoints.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/go-swagno/swagno/v3/components/extensions"
 	"github.com/go-swagno/swagno/v3/components/http/response"
 	"github.com/go-swagno/swagno/v3/components/mime"
 	"github.com/go-swagno/swagno/v3/components/parameter"
@@ -27,10 +28,16 @@ const (
 // MediaType represents a media type object in OpenAPI 3.0
 // https://spec.openapis.org/oas/v3.0.3#media-type-object
 type MediaType struct {
-	Schema   *parameter.JsonResponseSchema         `json:"schema,omitempty"`
-	Example  interface{}                           `json:"example,omitempty"`
-	Examples map[string]parameter.ComponentExample `json:"examples,omitempty"`
-	Encoding map[string]interface{}                `json:"encoding,omitempty"`
+	Schema     *parameter.JsonResponseSchema         `json:"schema,omitempty"`
+	Example    interface{}                           `json:"example,omitempty"`
+	Examples   map[string]parameter.ComponentExample `json:"examples,omitempty"`
+	Encoding   map[string]interface{}                `json:"encoding,omitempty"`
+	Extensions extensions.Extensions                 `json:"-"`
+}
+
+func (m MediaType) MarshalJSON() ([]byte, error) {
+	type alias MediaType
+	return extensions.Merge(alias(m), m.Extensions)
 }
 
 // Callback represents a callback object in OpenAPI 3.0
@@ -55,6 +62,12 @@ type PathItem struct {
 	Trace       *JsonEndPoint             `json:"trace,omitempty"`
 	Servers     []OperationServer         `json:"servers,omitempty"`
 	Parameters  []parameter.JsonParameter `json:"parameters,omitempty"`
+	Extensions  extensions.Extensions     `json:"-"`
+}
+
+func (p PathItem) MarshalJSON() ([]byte, error) {
+	type alias PathItem
+	return extensions.Merge(alias(p), p.Extensions)
 }
 
 // Link represents a link object in OpenAPI 3.0
@@ -66,14 +79,26 @@ type Link struct {
 	RequestBody  interface{}            `json:"requestBody,omitempty"`
 	Description  string                 `json:"description,omitempty"`
 	Server       interface{}            `json:"server,omitempty"`
+	Extensions   extensions.Extensions  `json:"-"`
+}
+
+func (l Link) MarshalJSON() ([]byte, error) {
+	type alias Link
+	return extensions.Merge(alias(l), l.Extensions)
 }
 
 // RequestBody represents a request body in OpenAPI 3.0
 // https://spec.openapis.org/oas/v3.0.3#request-body-object
 type RequestBody struct {
-	Description string               `json:"description,omitempty"`
-	Content     map[string]MediaType `json:"content"`
-	Required    bool                 `json:"required,omitempty"`
+	Description string                `json:"description,omitempty"`
+	Content     map[string]MediaType  `json:"content"`
+	Required    bool                  `json:"required,omitempty"`
+	Extensions  extensions.Extensions `json:"-"`
+}
+
+func (r RequestBody) MarshalJSON() ([]byte, error) {
+	type alias RequestBody
+	return extensions.Merge(alias(r), r.Extensions)
 }
 
 // JsonEndPoint is the JSON model version of EndPoint object used for API purposes
@@ -91,10 +116,16 @@ type JsonEndPoint struct {
 	Deprecated   bool                                       `json:"deprecated,omitempty"`
 	Security     []map[security.SecuritySchemeName][]string `json:"security,omitempty"`
 	Servers      []OperationServer                          `json:"servers,omitempty"`
+	Extensions   extensions.Extensions                      `json:"-"`
 
 	// helpers for generation
 	Consume []mime.MIME `json:"-"`
 	Produce []mime.MIME `json:"-"`
+}
+
+func (j JsonEndPoint) MarshalJSON() ([]byte, error) {
+	type alias JsonEndPoint
+	return extensions.Merge(alias(j), j.Extensions)
 }
 
 // JsonResponse represents the structure of a response in the OpenAPI 3.0 specification.
@@ -108,6 +139,13 @@ type JsonResponse struct {
 
 	// Legacy field for compatibility
 	Schema *parameter.JsonResponseSchema `json:"schema,omitempty"`
+
+	Extensions extensions.Extensions `json:"-"`
+}
+
+func (r JsonResponse) MarshalJSON() ([]byte, error) {
+	type alias JsonResponse
+	return extensions.Merge(alias(r), r.Extensions)
 }
 
 // EndPoint holds the details of an API endpoint, including HTTP method, path, parameters,
@@ -134,6 +172,7 @@ type EndPoint struct {
 	deprecated        bool
 	callbacks         map[string]Callback
 	servers           []OperationServer
+	extensions        extensions.Extensions
 }
 
 // AsJson converts an EndPoint into its JSON representation as JsonEndPoint.
@@ -148,6 +187,7 @@ func (e *EndPoint) AsJson() JsonEndPoint {
 		Deprecated:  e.deprecated,
 		Callbacks:   e.callbacks,
 		Servers:     e.servers,
+		Extensions:  e.extensions,
 
 		Consume: e.consume,
 		Produce: e.produce,
@@ -395,6 +435,28 @@ func WithCallbacks(callbacks map[string]Callback) EndPointOption {
 func WithServers(servers []OperationServer) EndPointOption {
 	return func(e *EndPoint) {
 		e.servers = servers
+	}
+}
+
+// WithExtensions merges the given OpenAPI extensions onto the endpoint.
+func WithExtensions(ext extensions.Extensions) EndPointOption {
+	return func(e *EndPoint) {
+		if e.extensions == nil {
+			e.extensions = extensions.Extensions{}
+		}
+		for k, v := range ext {
+			e.extensions[k] = v
+		}
+	}
+}
+
+// WithExtension sets a single OpenAPI extension entry on the endpoint.
+func WithExtension(key string, value any) EndPointOption {
+	return func(e *EndPoint) {
+		if e.extensions == nil {
+			e.extensions = extensions.Extensions{}
+		}
+		e.extensions[key] = value
 	}
 }
 

--- a/v3/components/endpoint/operation_fixes.go
+++ b/v3/components/endpoint/operation_fixes.go
@@ -1,9 +1,17 @@
 package endpoint
 
+import "github.com/go-swagno/swagno/v3/components/extensions"
+
 // OperationExternalDocs represents external docs for an operation
 type OperationExternalDocs struct {
-	Description string `json:"description,omitempty"`
-	URL         string `json:"url"` // REQUIRED
+	Description string                `json:"description,omitempty"`
+	URL         string                `json:"url"` // REQUIRED
+	Extensions  extensions.Extensions `json:"-"`
+}
+
+func (ed OperationExternalDocs) MarshalJSON() ([]byte, error) {
+	type alias OperationExternalDocs
+	return extensions.Merge(alias(ed), ed.Extensions)
 }
 
 // NewOperationExternalDocs creates external docs for operation
@@ -19,13 +27,25 @@ type OperationServer struct {
 	URL         string                             `json:"url"`
 	Description string                             `json:"description,omitempty"`
 	Variables   map[string]OperationServerVariable `json:"variables,omitempty"`
+	Extensions  extensions.Extensions              `json:"-"`
+}
+
+func (s OperationServer) MarshalJSON() ([]byte, error) {
+	type alias OperationServer
+	return extensions.Merge(alias(s), s.Extensions)
 }
 
 // OperationServerVariable represents a server variable object for operations
 type OperationServerVariable struct {
-	Enum        []string `json:"enum,omitempty"`
-	Default     string   `json:"default"`
-	Description string   `json:"description,omitempty"`
+	Enum        []string              `json:"enum,omitempty"`
+	Default     string                `json:"default"`
+	Description string                `json:"description,omitempty"`
+	Extensions  extensions.Extensions `json:"-"`
+}
+
+func (s OperationServerVariable) MarshalJSON() ([]byte, error) {
+	type alias OperationServerVariable
+	return extensions.Merge(alias(s), s.Extensions)
 }
 
 // NewOperationServer creates a new OperationServer instance

--- a/v3/components/extensions/extensions.go
+++ b/v3/components/extensions/extensions.go
@@ -1,0 +1,46 @@
+// Package extensions implements OpenAPI Specification Extensions (x-*).
+//
+// The OpenAPI spec allows vendor- or tool-specific fields on most objects,
+// provided their keys are prefixed with "x-". Any other key is not a valid
+// extension and is dropped at serialization time.
+//
+// See: https://spec.openapis.org/oas/v3.0.3#specification-extensions
+package extensions
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Extensions is a set of OpenAPI Specification Extension fields. Keys that do
+// not start with "x-" are ignored when the host object is serialized.
+type Extensions map[string]any
+
+// Prefix is the required prefix for OpenAPI extension keys.
+const Prefix = "x-"
+
+// Merge serializes v with the standard JSON marshaler and splices the x-*
+// entries of ext into the resulting object.
+//
+// Callers must pass a type alias of the host struct (one without its own
+// MarshalJSON method) so this call does not recurse.
+func Merge(v any, ext Extensions) ([]byte, error) {
+	base, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	if len(ext) == 0 {
+		return base, nil
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(base, &m); err != nil {
+		return nil, err
+	}
+	for k, val := range ext {
+		if strings.HasPrefix(k, Prefix) {
+			m[k] = val
+		}
+	}
+	return json.Marshal(m)
+}

--- a/v3/components/parameter/parameter.go
+++ b/v3/components/parameter/parameter.go
@@ -3,15 +3,23 @@ package parameter
 import (
 	"fmt"
 	"strings"
+
+	"github.com/go-swagno/swagno/v3/components/extensions"
 )
 
 // ComponentExample represents an example object for parameters
 // This is a simplified version to avoid import cycles
 type ComponentExample struct {
-	Summary       string      `json:"summary,omitempty"`
-	Description   string      `json:"description,omitempty"`
-	Value         interface{} `json:"value,omitempty"`
-	ExternalValue string      `json:"externalValue,omitempty"`
+	Summary       string                `json:"summary,omitempty"`
+	Description   string                `json:"description,omitempty"`
+	Value         interface{}           `json:"value,omitempty"`
+	ExternalValue string                `json:"externalValue,omitempty"`
+	Extensions    extensions.Extensions `json:"-"`
+}
+
+func (c ComponentExample) MarshalJSON() ([]byte, error) {
+	type alias ComponentExample
+	return extensions.Merge(alias(c), c.Extensions)
 }
 
 // CollectionFormat defines the format for serializing array parameters in the URL query string.
@@ -83,6 +91,12 @@ type JsonParameter struct {
 	Example         interface{}                 `json:"example,omitempty"`
 	Examples        map[string]ComponentExample `json:"examples,omitempty"`
 	Content         map[string]interface{}      `json:"content,omitempty"`
+	Extensions      extensions.Extensions       `json:"-"`
+}
+
+func (p JsonParameter) MarshalJSON() ([]byte, error) {
+	type alias JsonParameter
+	return extensions.Merge(alias(p), p.Extensions)
 }
 
 // JsonResponseSchema defines the schema for a JSON response as per the OpenAPI 3.0.3 specification.
@@ -120,27 +134,52 @@ type JsonResponseSchema struct {
 	Discriminator *Discriminator                 `json:"discriminator,omitempty"`
 	XML           *XML                           `json:"xml,omitempty"`
 	ExternalDocs  *ExternalDocs                  `json:"externalDocs,omitempty"`
+
+	Extensions extensions.Extensions `json:"-"`
+}
+
+func (s JsonResponseSchema) MarshalJSON() ([]byte, error) {
+	type alias JsonResponseSchema
+	return extensions.Merge(alias(s), s.Extensions)
 }
 
 // Discriminator represents the discriminator object for schema composition
 type Discriminator struct {
-	PropertyName string            `json:"propertyName"`
-	Mapping      map[string]string `json:"mapping,omitempty"`
+	PropertyName string                `json:"propertyName"`
+	Mapping      map[string]string     `json:"mapping,omitempty"`
+	Extensions   extensions.Extensions `json:"-"`
+}
+
+func (d Discriminator) MarshalJSON() ([]byte, error) {
+	type alias Discriminator
+	return extensions.Merge(alias(d), d.Extensions)
 }
 
 // XML represents the XML metadata for schema objects
 type XML struct {
-	Name      string `json:"name,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
-	Prefix    string `json:"prefix,omitempty"`
-	Attribute bool   `json:"attribute,omitempty"`
-	Wrapped   bool   `json:"wrapped,omitempty"`
+	Name       string                `json:"name,omitempty"`
+	Namespace  string                `json:"namespace,omitempty"`
+	Prefix     string                `json:"prefix,omitempty"`
+	Attribute  bool                  `json:"attribute,omitempty"`
+	Wrapped    bool                  `json:"wrapped,omitempty"`
+	Extensions extensions.Extensions `json:"-"`
+}
+
+func (x XML) MarshalJSON() ([]byte, error) {
+	type alias XML
+	return extensions.Merge(alias(x), x.Extensions)
 }
 
 // ExternalDocs represents external documentation for schema objects
 type ExternalDocs struct {
-	Description string `json:"description,omitempty"`
-	URL         string `json:"url"`
+	Description string                `json:"description,omitempty"`
+	URL         string                `json:"url"`
+	Extensions  extensions.Extensions `json:"-"`
+}
+
+func (ed ExternalDocs) MarshalJSON() ([]byte, error) {
+	type alias ExternalDocs
+	return extensions.Merge(alias(ed), ed.Extensions)
 }
 
 // JsonResponseSchemeItems represents the individual items in a JsonResponseSchema, especially for arrays.

--- a/v3/components/security/oauth_flows.go
+++ b/v3/components/security/oauth_flows.go
@@ -1,21 +1,35 @@
 package security
 
+import "github.com/go-swagno/swagno/v3/components/extensions"
+
 // OAuthFlows represents OAuth2 flows in OpenAPI 3.0
 // https://spec.openapis.org/oas/v3.0.3#oauth-flows-object
 type OAuthFlows struct {
-	Implicit          *OAuthFlow `json:"implicit,omitempty"`
-	Password          *OAuthFlow `json:"password,omitempty"`
-	ClientCredentials *OAuthFlow `json:"clientCredentials,omitempty"`
-	AuthorizationCode *OAuthFlow `json:"authorizationCode,omitempty"`
+	Implicit          *OAuthFlow            `json:"implicit,omitempty"`
+	Password          *OAuthFlow            `json:"password,omitempty"`
+	ClientCredentials *OAuthFlow            `json:"clientCredentials,omitempty"`
+	AuthorizationCode *OAuthFlow            `json:"authorizationCode,omitempty"`
+	Extensions        extensions.Extensions `json:"-"`
+}
+
+func (f OAuthFlows) MarshalJSON() ([]byte, error) {
+	type alias OAuthFlows
+	return extensions.Merge(alias(f), f.Extensions)
 }
 
 // OAuthFlow represents a single OAuth2 flow
 // https://spec.openapis.org/oas/v3.0.3#oauth-flow-object
 type OAuthFlow struct {
-	AuthorizationUrl string            `json:"authorizationUrl,omitempty"`
-	TokenUrl         string            `json:"tokenUrl,omitempty"`
-	RefreshUrl       string            `json:"refreshUrl,omitempty"`
-	Scopes           map[string]string `json:"scopes"`
+	AuthorizationUrl string                `json:"authorizationUrl,omitempty"`
+	TokenUrl         string                `json:"tokenUrl,omitempty"`
+	RefreshUrl       string                `json:"refreshUrl,omitempty"`
+	Scopes           map[string]string     `json:"scopes"`
+	Extensions       extensions.Extensions `json:"-"`
+}
+
+func (f OAuthFlow) MarshalJSON() ([]byte, error) {
+	type alias OAuthFlow
+	return extensions.Merge(alias(f), f.Extensions)
 }
 
 // NewOAuthFlows creates a new OAuth flows object

--- a/v3/components/tag/tag.go
+++ b/v3/components/tag/tag.go
@@ -1,15 +1,29 @@
 package tag
 
+import "github.com/go-swagno/swagno/v3/components/extensions"
+
 // https://spec.openapis.org/oas/v3.0.3#tag-object
 type Tag struct {
-	Name         string        `json:"name"`
-	Description  string        `json:"description"`
-	ExternalDocs *ExternalDocs `json:"externalDocs,omitempty"`
+	Name         string                `json:"name"`
+	Description  string                `json:"description"`
+	ExternalDocs *ExternalDocs         `json:"externalDocs,omitempty"`
+	Extensions   extensions.Extensions `json:"-"`
+}
+
+func (t Tag) MarshalJSON() ([]byte, error) {
+	type alias Tag
+	return extensions.Merge(alias(t), t.Extensions)
 }
 
 type ExternalDocs struct {
-	URL         string `json:"url"`
-	Description string `json:"description,omitempty"`
+	URL         string                `json:"url"`
+	Description string                `json:"description,omitempty"`
+	Extensions  extensions.Extensions `json:"-"`
+}
+
+func (ed ExternalDocs) MarshalJSON() ([]byte, error) {
+	type alias ExternalDocs
+	return extensions.Merge(alias(ed), ed.Extensions)
 }
 
 type TagOpts func(*Tag)

--- a/v3/extensions_test.go
+++ b/v3/extensions_test.go
@@ -1,0 +1,275 @@
+package swagno3
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/go-swagno/swagno/v3/components/definition"
+	"github.com/go-swagno/swagno/v3/components/endpoint"
+	"github.com/go-swagno/swagno/v3/components/extensions"
+	"github.com/go-swagno/swagno/v3/components/http/response"
+	"github.com/go-swagno/swagno/v3/components/mime"
+	"github.com/go-swagno/swagno/v3/components/parameter"
+	"github.com/go-swagno/swagno/v3/components/security"
+	"github.com/go-swagno/swagno/v3/components/tag"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+type TestExtPayload struct {
+	ID   uint64 `json:"id" example:"1"`
+	Name string `json:"name" example:"Alice"`
+}
+
+func TestExtensionsCombined(t *testing.T) {
+	cmpOpts := []cmp.Option{
+		cmpopts.IgnoreUnexported(OpenAPI{}, endpoint.EndPoint{}, endpoint.JsonEndPoint{}),
+		cmpopts.EquateEmpty(),
+		cmpopts.IgnoreFields(definition.SchemaProperty{}, "IsRequired"),
+		cmpopts.SortSlices(func(a, b string) bool { return a < b }),
+	}
+
+	t.Run("Operations", func(t *testing.T) {
+		testEndpoint := endpoint.New(
+			endpoint.GET,
+			"/product",
+			endpoint.WithSuccessfulReturns([]response.Response{
+				response.New(TestExtPayload{}, "200", "OK"),
+			}),
+			endpoint.WithExtension("x-rate-limit", 100),
+			endpoint.WithExtensions(extensions.Extensions{
+				"x-internal-id": "product.list",
+			}),
+		)
+
+		openapi := New(Config{Title: "Ext API", Version: "1.0.0"})
+		openapi.AddEndpoint(testEndpoint)
+		openapi.generateOpenAPIJson()
+
+		expected := &OpenAPI{
+			OpenAPI: "3.0.3",
+			Info:    Info{Title: "Ext API", Version: "1.0.0"},
+			Servers: []Server{{URL: "/"}},
+			Paths: map[string]endpoint.PathItem{
+				"/product": {
+					Get: &endpoint.JsonEndPoint{
+						OperationId: "get-_product",
+						Consume:     []mime.MIME{mime.JSON},
+						Produce:     []mime.MIME{mime.JSON},
+						Responses: map[string]endpoint.JsonResponse{
+							"200": {
+								Description: "OK",
+								Content: map[string]endpoint.MediaType{
+									"application/json": {
+										Schema: &parameter.JsonResponseSchema{
+											Ref: "#/components/schemas/swagno3.TestExtPayload",
+										},
+									},
+								},
+							},
+						},
+						Extensions: extensions.Extensions{
+							"x-rate-limit":  100,
+							"x-internal-id": "product.list",
+						},
+					},
+				},
+			},
+			Components: &Components{
+				Schemas: map[string]definition.Schema{
+					"swagno3.TestExtPayload": {
+						Type: "object",
+						Properties: map[string]definition.SchemaProperty{
+							"id":   {Type: "integer", Example: float64(1)},
+							"name": {Type: "string", Example: "Alice"},
+						},
+						Required: []string{"id", "name"},
+					},
+				},
+				SecuritySchemes: make(map[security.SecuritySchemeName]SecurityScheme),
+			},
+			Tags: []tag.Tag{},
+		}
+
+		if diff := cmp.Diff(expected, openapi, cmpOpts...); diff != "" {
+			t.Errorf("OpenAPI mismatch (-expected +got):\n%s", diff)
+		}
+	})
+
+	t.Run("DocumentAndInfo", func(t *testing.T) {
+		openapi := New(Config{
+			Title:          "Ext API",
+			Version:        "1.0.0",
+			Extensions:     extensions.Extensions{"x-audience": "internal"},
+			InfoExtensions: extensions.Extensions{"x-logo": map[string]string{"url": "https://example.com/logo.png"}},
+		})
+		openapi.generateOpenAPIJson()
+
+		expected := &OpenAPI{
+			OpenAPI: "3.0.3",
+			Info: Info{
+				Title:      "Ext API",
+				Version:    "1.0.0",
+				Extensions: extensions.Extensions{"x-logo": map[string]string{"url": "https://example.com/logo.png"}},
+			},
+			Servers:    []Server{{URL: "/"}},
+			Paths:      map[string]endpoint.PathItem{},
+			Extensions: extensions.Extensions{"x-audience": "internal"},
+			Components: &Components{
+				Schemas:         map[string]definition.Schema{},
+				SecuritySchemes: make(map[security.SecuritySchemeName]SecurityScheme),
+			},
+			Tags: []tag.Tag{},
+		}
+
+		if diff := cmp.Diff(expected, openapi, cmpOpts...); diff != "" {
+			t.Errorf("OpenAPI mismatch (-expected +got):\n%s", diff)
+		}
+	})
+
+	t.Run("TagsAndServers", func(t *testing.T) {
+		openapi := New(Config{Title: "Ext API", Version: "1.0.0"})
+		openapi.AddServer("https://api.example.com/v1", "Production")
+		openapi.Servers[0].Extensions = extensions.Extensions{"x-env": "prod"}
+
+		openapi.AddTags(tag.New("users", "User endpoints",
+			tag.WithExternalDocs("https://docs.example.com/users", "User docs"),
+		))
+		openapi.Tags[0].Extensions = extensions.Extensions{"x-display-name": "Users"}
+		openapi.Tags[0].ExternalDocs.Extensions = extensions.Extensions{"x-last-reviewed": "2026-04-01"}
+
+		openapi.generateOpenAPIJson()
+
+		expected := &OpenAPI{
+			OpenAPI: "3.0.3",
+			Info:    Info{Title: "Ext API", Version: "1.0.0"},
+			Servers: []Server{{
+				URL:         "https://api.example.com/v1",
+				Description: "Production",
+				Extensions:  extensions.Extensions{"x-env": "prod"},
+			}},
+			Paths: map[string]endpoint.PathItem{},
+			Components: &Components{
+				Schemas:         map[string]definition.Schema{},
+				SecuritySchemes: make(map[security.SecuritySchemeName]SecurityScheme),
+			},
+			Tags: []tag.Tag{{
+				Name:        "users",
+				Description: "User endpoints",
+				ExternalDocs: &tag.ExternalDocs{
+					URL:         "https://docs.example.com/users",
+					Description: "User docs",
+					Extensions:  extensions.Extensions{"x-last-reviewed": "2026-04-01"},
+				},
+				Extensions: extensions.Extensions{"x-display-name": "Users"},
+			}},
+		}
+
+		if diff := cmp.Diff(expected, openapi, cmpOpts...); diff != "" {
+			t.Errorf("OpenAPI mismatch (-expected +got):\n%s", diff)
+		}
+	})
+
+	t.Run("SchemasAndParameters", func(t *testing.T) {
+		testEndpoint := endpoint.New(
+			endpoint.GET,
+			"/users/{id}",
+			endpoint.WithParams(parameter.IntParam("id", parameter.Path, parameter.WithRequired())),
+			endpoint.WithSuccessfulReturns([]response.Response{
+				response.New(TestExtPayload{}, "200", "OK"),
+			}),
+		)
+
+		openapi := New(Config{Title: "Ext API", Version: "1.0.0"})
+		openapi.AddEndpoint(testEndpoint)
+		openapi.generateOpenAPIJson()
+
+		// Post-generation mutations: users set extensions on auto-generated
+		// schemas and parameters via the exposed structs.
+		schemaKey := "swagno3.TestExtPayload"
+		s := openapi.Components.Schemas[schemaKey]
+		s.Extensions = extensions.Extensions{"x-internal-id": "payload-v1"}
+		openapi.Components.Schemas[schemaKey] = s
+
+		pi := openapi.Paths["/users/{id}"]
+		pi.Get.Parameters[0].Extensions = extensions.Extensions{"x-source": "auth"}
+		openapi.Paths["/users/{id}"] = pi
+
+		expected := &OpenAPI{
+			OpenAPI: "3.0.3",
+			Info:    Info{Title: "Ext API", Version: "1.0.0"},
+			Servers: []Server{{URL: "/"}},
+			Paths: map[string]endpoint.PathItem{
+				"/users/{id}": {
+					Get: &endpoint.JsonEndPoint{
+						OperationId: "get-_users_id",
+						Consume:     []mime.MIME{mime.JSON},
+						Produce:     []mime.MIME{mime.JSON},
+						Parameters: []parameter.JsonParameter{{
+							Name:     "id",
+							In:       "path",
+							Required: true,
+							Schema:   &parameter.JsonResponseSchema{Type: "integer"},
+							Extensions: extensions.Extensions{"x-source": "auth"},
+						}},
+						Responses: map[string]endpoint.JsonResponse{
+							"200": {
+								Description: "OK",
+								Content: map[string]endpoint.MediaType{
+									"application/json": {
+										Schema: &parameter.JsonResponseSchema{
+											Ref: "#/components/schemas/swagno3.TestExtPayload",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Components: &Components{
+				Schemas: map[string]definition.Schema{
+					"swagno3.TestExtPayload": {
+						Type: "object",
+						Properties: map[string]definition.SchemaProperty{
+							"id":   {Type: "integer", Example: float64(1)},
+							"name": {Type: "string", Example: "Alice"},
+						},
+						Required:   []string{"id", "name"},
+						Extensions: extensions.Extensions{"x-internal-id": "payload-v1"},
+					},
+				},
+				SecuritySchemes: make(map[security.SecuritySchemeName]SecurityScheme),
+			},
+			Tags: []tag.Tag{},
+		}
+
+		if diff := cmp.Diff(expected, openapi, cmpOpts...); diff != "" {
+			t.Errorf("OpenAPI mismatch (-expected +got):\n%s", diff)
+		}
+	})
+}
+
+// TestMergeRejectsNonExtensionKeys is a unit test for the shared helper that
+// filters keys not prefixed with "x-" at serialization time.
+func TestMergeRejectsNonExtensionKeys(t *testing.T) {
+	out, err := extensions.Merge(struct {
+		A string `json:"a"`
+	}{A: "1"}, extensions.Extensions{
+		"x-ok": "yes",
+		"bad":  "nope",
+	})
+	if err != nil {
+		t.Fatalf("merge failed: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if m["x-ok"] != "yes" {
+		t.Errorf("x-ok missing")
+	}
+	if _, ok := m["bad"]; ok {
+		t.Errorf("non-extension key leaked: %v", m)
+	}
+}

--- a/v3/external_docs.go
+++ b/v3/external_docs.go
@@ -1,6 +1,10 @@
 package swagno3
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/go-swagno/swagno/v3/components/extensions"
+)
 
 // ErrExternalDocsURLRequired is returned when URL field is empty in ExternalDocs
 var ErrExternalDocsURLRequired = errors.New("externalDocs URL field is required")
@@ -8,8 +12,14 @@ var ErrExternalDocsURLRequired = errors.New("externalDocs URL field is required"
 // ExternalDocs represents external documentation object
 // https://spec.openapis.org/oas/v3.0.3#external-documentation-object
 type ExternalDocs struct {
-	Description string `json:"description,omitempty"`
-	URL         string `json:"url"` // REQUIRED
+	Description string                `json:"description,omitempty"`
+	URL         string                `json:"url"` // REQUIRED
+	Extensions  extensions.Extensions `json:"-"`
+}
+
+func (ed ExternalDocs) MarshalJSON() ([]byte, error) {
+	type alias ExternalDocs
+	return extensions.Merge(alias(ed), ed.Extensions)
 }
 
 // NewExternalDocs creates a new ExternalDocs instance

--- a/v3/openapi.go
+++ b/v3/openapi.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-swagno/swagno/v3/components/definition"
 	"github.com/go-swagno/swagno/v3/components/endpoint"
+	"github.com/go-swagno/swagno/v3/components/extensions"
 	"github.com/go-swagno/swagno/v3/components/parameter"
 	"github.com/go-swagno/swagno/v3/components/security"
 	"github.com/go-swagno/swagno/v3/components/tag"
@@ -23,19 +24,32 @@ type OpenAPI struct {
 	Tags         []tag.Tag                    `json:"tags,omitempty"`
 	Security     []map[string][]string        `json:"security,omitempty"`
 	ExternalDocs *ExternalDocs                `json:"externalDocs,omitempty"`
-	endpoints    []*endpoint.EndPoint
+	Extensions   extensions.Extensions        `json:"-"`
+
+	endpoints []*endpoint.EndPoint
+}
+
+func (o OpenAPI) MarshalJSON() ([]byte, error) {
+	type alias OpenAPI
+	return extensions.Merge(alias(o), o.Extensions)
 }
 
 // Info represents the information about the API.
 // https://spec.openapis.org/oas/v3.0.3#info-object
 type Info struct {
-	Title          string   `json:"title"`
-	Summary        string   `json:"summary,omitempty"`
-	Description    string   `json:"description,omitempty"`
-	Version        string   `json:"version"`
-	TermsOfService string   `json:"termsOfService,omitempty"`
-	Contact        *Contact `json:"contact,omitempty"`
-	License        *License `json:"license,omitempty"`
+	Title          string                `json:"title"`
+	Summary        string                `json:"summary,omitempty"`
+	Description    string                `json:"description,omitempty"`
+	Version        string                `json:"version"`
+	TermsOfService string                `json:"termsOfService,omitempty"`
+	Contact        *Contact              `json:"contact,omitempty"`
+	License        *License              `json:"license,omitempty"`
+	Extensions     extensions.Extensions `json:"-"`
+}
+
+func (i Info) MarshalJSON() ([]byte, error) {
+	type alias Info
+	return extensions.Merge(alias(i), i.Extensions)
 }
 
 // Server represents a server object in OpenAPI 3.0
@@ -44,14 +58,26 @@ type Server struct {
 	URL         string                    `json:"url"`
 	Description string                    `json:"description,omitempty"`
 	Variables   map[string]ServerVariable `json:"variables,omitempty"`
+	Extensions  extensions.Extensions     `json:"-"`
+}
+
+func (s Server) MarshalJSON() ([]byte, error) {
+	type alias Server
+	return extensions.Merge(alias(s), s.Extensions)
 }
 
 // ServerVariable represents a server variable object
 // https://spec.openapis.org/oas/v3.0.3#server-variable-object
 type ServerVariable struct {
-	Enum        []string `json:"enum,omitempty"`
-	Default     string   `json:"default"`
-	Description string   `json:"description,omitempty"`
+	Enum        []string              `json:"enum,omitempty"`
+	Default     string                `json:"default"`
+	Description string                `json:"description,omitempty"`
+	Extensions  extensions.Extensions `json:"-"`
+}
+
+func (s ServerVariable) MarshalJSON() ([]byte, error) {
+	type alias ServerVariable
+	return extensions.Merge(alias(s), s.Extensions)
 }
 
 // Components holds a set of reusable objects for different aspects of the OAS
@@ -66,6 +92,12 @@ type Components struct {
 	SecuritySchemes map[security.SecuritySchemeName]SecurityScheme `json:"securitySchemes,omitempty"`
 	Links           map[string]endpoint.Link                       `json:"links,omitempty"`
 	Callbacks       map[string]endpoint.Callback                   `json:"callbacks,omitempty"`
+	Extensions      extensions.Extensions                          `json:"-"`
+}
+
+func (c Components) MarshalJSON() ([]byte, error) {
+	type alias Components
+	return extensions.Merge(alias(c), c.Extensions)
 }
 
 // SecurityScheme represents a security scheme in OpenAPI 3.0
@@ -79,6 +111,12 @@ type SecurityScheme struct {
 	BearerFormat     string                      `json:"bearerFormat,omitempty"`
 	Flows            *security.OAuthFlows        `json:"flows,omitempty"`
 	OpenIdConnectUrl string                      `json:"openIdConnectUrl,omitempty"`
+	Extensions       extensions.Extensions       `json:"-"`
+}
+
+func (s SecurityScheme) MarshalJSON() ([]byte, error) {
+	type alias SecurityScheme
+	return extensions.Merge(alias(s), s.Extensions)
 }
 
 // New creates a new OpenAPI instance with the provided config
@@ -120,29 +158,43 @@ func (o *OpenAPI) AddServer(url string, description string) {
 // Contact represents the contact information for the API.
 // https://spec.openapis.org/oas/v3.0.3#contact-object
 type Contact struct {
-	Name  string `json:"name,omitempty"`
-	URL   string `json:"url,omitempty"`
-	Email string `json:"email,omitempty"`
+	Name       string                `json:"name,omitempty"`
+	URL        string                `json:"url,omitempty"`
+	Email      string                `json:"email,omitempty"`
+	Extensions extensions.Extensions `json:"-"`
+}
+
+func (c Contact) MarshalJSON() ([]byte, error) {
+	type alias Contact
+	return extensions.Merge(alias(c), c.Extensions)
 }
 
 // License represents the license information for the API.
 // https://spec.openapis.org/oas/v3.0.3#license-object
 type License struct {
-	Name string `json:"name"`
-	URL  string `json:"url,omitempty"`
+	Name       string                `json:"name"`
+	URL        string                `json:"url,omitempty"`
+	Extensions extensions.Extensions `json:"-"`
+}
+
+func (l License) MarshalJSON() ([]byte, error) {
+	type alias License
+	return extensions.Merge(alias(l), l.Extensions)
 }
 
 // Config struct represents the configuration for OpenAPI documentation.
 type Config struct {
-	Title          string        // title of the OpenAPI documentation
-	Version        string        // version of the OpenAPI documentation
-	Summary        string        // summary of the OpenAPI documentation
-	Description    string        // description of the OpenAPI documentation
-	Servers        []Server      // servers for the API
-	License        *License      // license information for the OpenAPI documentation
-	Contact        *Contact      // contact information for the OpenAPI documentation
-	TermsOfService string        // term of service information for the OpenAPI documentation
-	ExternalDocs   *ExternalDocs // external documentation
+	Title          string                // title of the OpenAPI documentation
+	Version        string                // version of the OpenAPI documentation
+	Summary        string                // summary of the OpenAPI documentation
+	Description    string                // description of the OpenAPI documentation
+	Servers        []Server              // servers for the API
+	License        *License              // license information for the OpenAPI documentation
+	Contact        *Contact              // contact information for the OpenAPI documentation
+	TermsOfService string                // term of service information for the OpenAPI documentation
+	ExternalDocs   *ExternalDocs         // external documentation
+	Extensions     extensions.Extensions // root-level OpenAPI extensions (x-*)
+	InfoExtensions extensions.Extensions // extensions on the Info object (x-*)
 }
 
 // buildOpenAPI creates a new OpenAPI instance with the given configuration.
@@ -164,9 +216,11 @@ func buildOpenAPI(c Config) (openapi *OpenAPI) {
 			License:        c.License,
 			Contact:        c.Contact,
 			TermsOfService: c.TermsOfService,
+			Extensions:     c.InfoExtensions,
 		},
 		Servers:      c.Servers,
 		ExternalDocs: c.ExternalDocs,
+		Extensions:   c.Extensions,
 		Paths:        make(map[string]endpoint.PathItem),
 		Components: &Components{
 			Schemas:         make(map[string]definition.Schema),
@@ -190,7 +244,7 @@ func (openapi *OpenAPI) ExportOpenAPIDocs(out_file string) string {
 	if err != nil {
 		log.Println("Error while generating openapi json")
 	}
-	err = os.WriteFile(out_file, json, 0644)
+	err = os.WriteFile(out_file, json, 0o644)
 	if err != nil {
 		log.Println("Error writing openapi file")
 	}
@@ -200,10 +254,16 @@ func (openapi *OpenAPI) ExportOpenAPIDocs(out_file string) string {
 // ComponentExample represents an example object in components
 // https://spec.openapis.org/oas/v3.0.3#example-object
 type ComponentExample struct {
-	Summary       string      `json:"summary,omitempty"`
-	Description   string      `json:"description,omitempty"`
-	Value         interface{} `json:"value,omitempty"`
-	ExternalValue string      `json:"externalValue,omitempty"`
+	Summary       string                `json:"summary,omitempty"`
+	Description   string                `json:"description,omitempty"`
+	Value         interface{}           `json:"value,omitempty"`
+	ExternalValue string                `json:"externalValue,omitempty"`
+	Extensions    extensions.Extensions `json:"-"`
+}
+
+func (c ComponentExample) MarshalJSON() ([]byte, error) {
+	type alias ComponentExample
+	return extensions.Merge(alias(c), c.Extensions)
 }
 
 // ComponentHeader represents a header object in components
@@ -219,4 +279,10 @@ type ComponentHeader struct {
 	Schema          *definition.Schema          `json:"schema,omitempty"`
 	Example         interface{}                 `json:"example,omitempty"`
 	Examples        map[string]ComponentExample `json:"examples,omitempty"`
+	Extensions      extensions.Extensions       `json:"-"`
+}
+
+func (c ComponentHeader) MarshalJSON() ([]byte, error) {
+	type alias ComponentHeader
+	return extensions.Merge(alias(c), c.Extensions)
 }


### PR DESCRIPTION
The v3 README still lists specification extensions as _coming soon_, but I couldn't find any progress on it and I thought adding a PR for it may benefit more users.

Just as context, it's adding support for `x-*` keys are defined by the OpenAPI spec itself (https://swagger.io/specification/, https://spec.openapis.org/oas/v3.0.3#specification-extensions). There are ~22 objects in 3.0.3 include "This object MAY be extended with Specification Extensions", meaning any key prefixed with `x-` should serialize as a sibling of the object's normal fields (i.e. on the same level).

For every v3 struct that maps to one of those spec objects I added an `Extensions` field tagged `json:"-"`, plus a custom `MarshalJSON`:

 ```go
  func (j JsonEndPoint) MarshalJSON() ([]byte, error) {
      type alias JsonEndPoint
      return extensions.Merge(alias(j), j.Extensions)
  }
 ```

The `extensions.Merge` is a shared helper that just merges the `x-*` keys to the map. So the whole flow now is: default marshal -> unmarshal to map -> merge `x-*` entries -> re-marshal.

I thought that using a type alias and then marshalling with `json.Marshal(alias(j))` is slightly cleaner (and easier to maintain) than having each key rewritten in the custom marshaller (kin-openapi uses this idea, they hand-build the map in `MarshalYAML` and reuse that in the json marshaller: https://github.com/getkin/kin-openapi/blob/master/openapi3/operation.go#L70-L74)

For the common case, there are builder/Config options:

```go
  endpoint.New(endpoint.GET, "/users/{id}",
      endpoint.WithExtension("x-rate-limit", 100),
      endpoint.WithExtensions(extensions.Extensions{"x-code-samples": ...}),
  )

  swagno3.New(swagno3.Config{
      Title:          "My API",
      Extensions:     extensions.Extensions{"x-audience": "internal"},
      InfoExtensions: extensions.Extensions{"x-logo": ...},
  })
```

## Coverage

Every v3 struct that maps to a spec object permitting extensions: OpenAPI, Info, Contact, License, Server, ServerVariable, Components, ComponentExample, ComponentHeader, SecurityScheme, ExternalDocs (root + the duplicates in `definition`/`parameter`/`tag`/`endpoint`), Schema, Discriminator, XML, JsonEndPoint, PathItem, MediaType, Link, RequestBody, JsonResponse, OperationServer + variable, JsonParameter, JsonResponseSchema, Tag, OAuthFlows, OAuthFlow.

One gap: four spec objects are modeled as bare Go maps in swagno (Paths, Responses, Security Requirement, Encoding), so there's no `MarshalJSON` to attach extensions to. This would need a small structural change like wrapping each in a named struct, but I left it out to keep this PR focused - happy to include it here or as a follow-up.