### PR TITLE
Add hiding package names option

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,20 +242,44 @@ You can use the swagger config when creating new swagger object
 
 ```go
 type Config struct {
-  Title          string   // title of the Swagger documentation
-  Version        string   // version of the Swagger documentation
-  Description    string   // description of the Swagger documentation
-  Host           string   // host URL for the API
-  Path           string   // path to the Swagger JSON file
-  License        *License // license information for the Swagger documentation
-  Contact        *Contact // contact information for the Swagger documentation
-  TermsOfService string   // term of service information for the Swagger documentation
+  Title           string   // title of the Swagger documentation
+  Version         string   // version of the Swagger documentation
+  Description     string   // description of the Swagger documentation
+  Host            string   // host URL for the API
+  Path            string   // path to the Swagger JSON file
+  License         *License // license information for the Swagger documentation
+  Contact         *Contact // contact information for the Swagger documentation
+  TermsOfService  string   // term of service information for the Swagger documentation
+  HidePackageName bool     // reference models without their package qualifier (e.g. "MyStruct" instead of "models.MyStruct")
 }
 ```
 
 ```go
 sw := swagno.New(swagno.Config{Title: "Testing API", Version: "v1.0.0", Host: "localhost:8080"}) // optionally you can also use the License and Info properties as well
 ```
+
+### Hiding the package name in model references
+
+By default, models are referenced by their package-qualified name, so a `models.MyStruct`
+type appears in the documentation as `#/definitions/models.MyStruct`. Set
+`HidePackageName: true` to drop the package qualifier and reference the model as just
+`#/definitions/MyStruct`:
+
+```go
+sw := swagno.New(swagno.Config{Title: "Testing API", Version: "v1.0.0", HidePackageName: true})
+```
+
+| `HidePackageName` | Reference in the generated docs |
+| ----------------- | ------------------------------- |
+| `false` (default) | `#/definitions/models.MyStruct` |
+| `true`            | `#/definitions/MyStruct`        |
+
+> **Note:** Enabling this option can cause collisions when two packages declare a type with
+> the same name (e.g. `models.User` and `dto.User` would both become `User`). Only enable it
+> when your model names are unique across packages.
+
+The same option is available on the v3 `swagno3.Config` and affects
+`#/components/schemas/...` references.
 
 ## Endpoints (API)
 

--- a/components/definition/definition.go
+++ b/components/definition/definition.go
@@ -42,20 +42,24 @@ type DefinitionPropertiesItems struct {
 // of adding new definitions based on reflected types.
 type DefinitionGenerator struct {
 	Definitions map[string]Definition
+	// HidePackageName, when true, strips the leading package qualifier from
+	// definition names and $ref values (e.g. "models.MyStruct" -> "MyStruct").
+	HidePackageName bool
 }
 
 // NewDefinitionGenerator is a constructor function that initializes
 // a DefinitionGenerator with a provided map of Definition objects.
-func NewDefinitionGenerator(definitionMap map[string]Definition) *DefinitionGenerator {
+func NewDefinitionGenerator(definitionMap map[string]Definition, hidePackageName bool) *DefinitionGenerator {
 	return &DefinitionGenerator{
-		Definitions: definitionMap,
+		Definitions:     definitionMap,
+		HidePackageName: hidePackageName,
 	}
 }
 
 // CreateDefinition analyzes the type of the provided value 't' and adds a corresponding Definition to the generator's Definitions map.
 func (g DefinitionGenerator) CreateDefinition(t interface{}) {
 	properties := make(map[string]DefinitionProperties)
-	definitionName := fmt.Sprintf("%T", t)
+	definitionName := fields.RefName(fmt.Sprintf("%T", t), g.HidePackageName)
 
 	reflectReturn := reflect.TypeOf(t)
 	switch reflectReturn.Kind() {
@@ -137,7 +141,7 @@ func (g DefinitionGenerator) createStructDefinitions(structType reflect.Type) ma
 						Example: fields.ExampleTag(field),
 						Type:    fieldType,
 						Items: &DefinitionPropertiesItems{
-							Ref: fmt.Sprintf("#/definitions/%s", field.Type.Elem().Elem().String()),
+							Ref: fmt.Sprintf("#/definitions/%s", fields.RefName(field.Type.Elem().Elem().String(), g.HidePackageName)),
 						},
 						IsRequired: g.isRequired(field),
 					}
@@ -161,7 +165,7 @@ func (g DefinitionGenerator) createStructDefinitions(structType reflect.Type) ma
 					Example: fields.ExampleTag(field),
 					Type:    fieldType,
 					Items: &DefinitionPropertiesItems{
-						Ref: fmt.Sprintf("#/definitions/%s", field.Type.Elem().String()),
+						Ref: fmt.Sprintf("#/definitions/%s", fields.RefName(field.Type.Elem().String(), g.HidePackageName)),
 					},
 					IsRequired: g.isRequired(field),
 				}
@@ -189,7 +193,7 @@ func (g DefinitionGenerator) createStructDefinitions(structType reflect.Type) ma
 			} else {
 				properties[fieldJsonTag] = DefinitionProperties{
 					Example:    fields.ExampleTag(field),
-					Ref:        fmt.Sprintf("#/definitions/%s", field.Type.String()),
+					Ref:        fmt.Sprintf("#/definitions/%s", fields.RefName(field.Type.String(), g.HidePackageName)),
 					IsRequired: isRequiredField,
 				}
 				g.CreateDefinition(reflect.New(field.Type).Elem().Interface())
@@ -217,7 +221,7 @@ func (g DefinitionGenerator) createStructDefinitions(structType reflect.Type) ma
 						Example: fields.ExampleTag(field),
 						Type:    fields.Type(field.Type.Elem().Kind().String()),
 						Items: &DefinitionPropertiesItems{
-							Ref: fmt.Sprintf("#/definitions/%s", field.Type.Elem().Elem().String()),
+							Ref: fmt.Sprintf("#/definitions/%s", fields.RefName(field.Type.Elem().Elem().String(), g.HidePackageName)),
 						},
 					}
 					if structType == field.Type.Elem().Elem() {
@@ -241,7 +245,7 @@ func (g DefinitionGenerator) createStructDefinitions(structType reflect.Type) ma
 			}
 
 		case "map":
-			name := fmt.Sprintf("%s.%s", structType.String(), fieldJsonTag)
+			name := fmt.Sprintf("%s.%s", fields.RefName(structType.String(), g.HidePackageName), fieldJsonTag)
 			mapKeyType := field.Type.Key()
 			mapValueType := field.Type.Elem()
 			if mapValueType.Kind() == reflect.Ptr {
@@ -255,7 +259,7 @@ func (g DefinitionGenerator) createStructDefinitions(structType reflect.Type) ma
 					Type: "object",
 					Properties: map[string]DefinitionProperties{
 						fields.Type(mapKeyType.String()): {
-							Ref: fmt.Sprintf("#/definitions/%s", mapValueType.String()),
+							Ref: fmt.Sprintf("#/definitions/%s", fields.RefName(mapValueType.String(), g.HidePackageName)),
 						},
 					},
 				}
@@ -308,7 +312,7 @@ func (g DefinitionGenerator) durationProperty(field reflect.StructField, require
 func (g DefinitionGenerator) refProperty(field reflect.StructField, required bool) DefinitionProperties {
 	return DefinitionProperties{
 		Example:    fields.ExampleTag(field),
-		Ref:        fmt.Sprintf("#/definitions/%s", field.Type.Elem().String()),
+		Ref:        fmt.Sprintf("#/definitions/%s", fields.RefName(field.Type.Elem().String(), g.HidePackageName)),
 		IsRequired: required,
 	}
 }

--- a/components/endpoint/endpoints.go
+++ b/components/endpoint/endpoints.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/go-swagno/swagno/components/fields"
 	"github.com/go-swagno/swagno/components/http/response"
 	"github.com/go-swagno/swagno/components/mime"
 	"github.com/go-swagno/swagno/components/parameter"
@@ -126,9 +127,9 @@ func (e *EndPoint) Path() string {
 
 // BodyJsonParameter makes the body definitions and parameter for body if present. Parameters for body are described via schema
 // definition so that's why it doesn't use the 'Parameter' object like the other ones.
-func (e *EndPoint) BodyJsonParameter() *parameter.JsonParameter {
+func (e *EndPoint) BodyJsonParameter(hidePackageName bool) *parameter.JsonParameter {
 	if e.Body.Content != nil {
-		bodyRef := fmt.Sprintf("#/definitions/%T", e.Body.Content)
+		bodyRef := fmt.Sprintf("#/definitions/%s", fields.RefName(fmt.Sprintf("%T", e.Body.Content), hidePackageName))
 		bodySchema := parameter.JsonResponseSchema{
 			Ref: bodyRef,
 		}
@@ -137,7 +138,7 @@ func (e *EndPoint) BodyJsonParameter() *parameter.JsonParameter {
 			bodySchema = parameter.JsonResponseSchema{
 				Type: "array",
 				Items: &parameter.JsonResponseSchemeItems{
-					Ref: fmt.Sprintf("#/definitions/%T", e.Body.Content),
+					Ref: fmt.Sprintf("#/definitions/%s", fields.RefName(fmt.Sprintf("%T", e.Body.Content), hidePackageName)),
 				},
 			}
 		}

--- a/components/fields/parsing.go
+++ b/components/fields/parsing.go
@@ -49,6 +49,20 @@ func IsRequired(field reflect.StructField) bool {
 	return tagValue == "true"
 }
 
+// RefName returns the type name with its leading package qualifier removed when
+// hidePackage is true (e.g. "models.MyStruct" -> "MyStruct"). It is a no-op when
+// hidePackage is false. Synthetic names such as "models.Product.metadata" become
+// "Product.metadata", since only the leading package segment is stripped.
+func RefName(name string, hidePackage bool) string {
+	if !hidePackage {
+		return name
+	}
+	if _, after, found := strings.Cut(name, "."); found {
+		return after
+	}
+	return name
+}
+
 // Type maps a string to its corresponding Swagger type according to the
 // Swagger Specification version 2 data types (https://swagger.io/specification/v2/#data-types).
 func Type(t string) string {

--- a/components/http/response/response.go
+++ b/components/http/response/response.go
@@ -23,7 +23,11 @@ type CustomResponse struct {
 }
 
 // ResponseGenerator is a struct that provides functionality to generate response schemas.
-type ResponseGenerator struct{}
+type ResponseGenerator struct {
+	// HidePackageName, when true, strips the leading package qualifier from $ref
+	// values (e.g. "models.MyStruct" -> "MyStruct").
+	HidePackageName bool
+}
 
 // New creates a new instance of Response with the provided model return code, and description.
 func New(model any, returnCode string, description string) CustomResponse {
@@ -35,8 +39,10 @@ func New(model any, returnCode string, description string) CustomResponse {
 }
 
 // NewResponseGenerator creates a new instance of ResponseGenerator.
-func NewResponseGenerator() *ResponseGenerator {
-	return &ResponseGenerator{}
+func NewResponseGenerator(hidePackageName bool) *ResponseGenerator {
+	return &ResponseGenerator{
+		HidePackageName: hidePackageName,
+	}
 }
 
 // Generate generates a JSON response schema based on the provided model.
@@ -50,7 +56,7 @@ func (g ResponseGenerator) Generate(model any) *parameter.JsonResponseSchema {
 			return &parameter.JsonResponseSchema{
 				Type: "array",
 				Items: &parameter.JsonResponseSchemeItems{
-					Ref: strings.ReplaceAll(fmt.Sprintf("#/definitions/%s", reflect.TypeOf(model).Elem().String()), "[]", ""),
+					Ref: fmt.Sprintf("#/definitions/%s", fields.RefName(strings.ReplaceAll(reflect.TypeOf(model).Elem().String(), "[]", ""), g.HidePackageName)),
 				},
 			}
 		} else {
@@ -63,7 +69,7 @@ func (g ResponseGenerator) Generate(model any) *parameter.JsonResponseSchema {
 		}
 
 	case reflect.Map:
-		ref := strings.ReplaceAll(fmt.Sprintf("#/definitions/%T", model), "[]", "")
+		ref := fmt.Sprintf("#/definitions/%s", fields.RefName(strings.ReplaceAll(fmt.Sprintf("%T", model), "[]", ""), g.HidePackageName))
 		return &parameter.JsonResponseSchema{
 			Ref: ref,
 		}
@@ -71,7 +77,7 @@ func (g ResponseGenerator) Generate(model any) *parameter.JsonResponseSchema {
 	default:
 		if hasStructFields(model) {
 			return &parameter.JsonResponseSchema{
-				Ref: strings.ReplaceAll(fmt.Sprintf("#/definitions/%T", model), "[]", ""),
+				Ref: fmt.Sprintf("#/definitions/%s", fields.RefName(strings.ReplaceAll(fmt.Sprintf("%T", model), "[]", ""), g.HidePackageName)),
 			}
 		}
 	}

--- a/docs/02-core-modules.md
+++ b/docs/02-core-modules.md
@@ -72,14 +72,15 @@ sw.AddTags(
 
 ```go
 type Config struct {
-    Title          string   // Title of the Swagger documentation
-    Version        string   // API version
-    Description    string   // API description
-    Host           string   // Host URL
-    Path           string   // Base path
-    License        *License // License information
-    Contact        *Contact // Contact information
-    TermsOfService string   // Terms of service
+    Title           string   // Title of the Swagger documentation
+    Version         string   // API version
+    Description     string   // API description
+    Host            string   // Host URL
+    Path            string   // Base path
+    License         *License // License information
+    Contact         *Contact // Contact information
+    TermsOfService  string   // Terms of service
+    HidePackageName bool     // reference models without their package qualifier (e.g. "MyStruct" instead of "models.MyStruct")
 }
 ```
 

--- a/docs/05-api-reference.md
+++ b/docs/05-api-reference.md
@@ -221,16 +221,22 @@ sw.SetOAuth2Auth("oauth2", "password", "", "http://localhost:8080/oauth/token", 
 
 ```go
 type Config struct {
-    Title          string
-    Version        string
-    Description    string
-    Host           string
-    Path           string
-    License        *License
-    Contact        *Contact
-    TermsOfService string
+    Title           string
+    Version         string
+    Description     string
+    Host            string
+    Path            string
+    License         *License
+    Contact         *Contact
+    TermsOfService  string
+    HidePackageName bool // reference models without their package qualifier (e.g. "MyStruct" instead of "models.MyStruct")
 }
 ```
+
+When `HidePackageName` is `true`, definition keys and `$ref` values omit the package
+qualifier — `#/definitions/models.MyStruct` becomes `#/definitions/MyStruct`. It defaults to
+`false`, preserving the package-qualified names. Enable it only when model names are unique
+across packages, since stripping the package can otherwise cause name collisions.
 
 #### `Info`
 

--- a/generate.go
+++ b/generate.go
@@ -12,8 +12,8 @@ import (
 	"github.com/go-swagno/swagno/components/parameter"
 )
 
-func appendResponses(sourceResponses map[string]endpoint.JsonResponse, additionalResponses []response.Response) map[string]endpoint.JsonResponse {
-	responseGenerator := response.NewResponseGenerator()
+func appendResponses(sourceResponses map[string]endpoint.JsonResponse, additionalResponses []response.Response, hidePackageName bool) map[string]endpoint.JsonResponse {
+	responseGenerator := response.NewResponseGenerator(hidePackageName)
 
 	for _, resp := range additionalResponses {
 		var responseSchema *parameter.JsonResponseSchema
@@ -70,14 +70,14 @@ func (s *Swagger) generateSwaggerJson() {
 			parameters = append(parameters, param.AsJson())
 		}
 
-		if bjp := e.BodyJsonParameter(); bjp != nil {
+		if bjp := e.BodyJsonParameter(s.hidePackageName); bjp != nil {
 			parameters = append(parameters, *bjp)
 		}
 
 		// Creates the schema defintion for all successful return and error objects, and then links them in the responses section
 		responses := map[string]endpoint.JsonResponse{}
-		responses = appendResponses(responses, e.SuccessfulReturns())
-		responses = appendResponses(responses, e.Errors())
+		responses = appendResponses(responses, e.SuccessfulReturns(), s.hidePackageName)
+		responses = appendResponses(responses, e.Errors(), s.hidePackageName)
 
 		// add each endpoint to paths field of swagger
 		je := e.AsJson()
@@ -125,6 +125,6 @@ func (s *Swagger) createDefinitions(r []response.Response) {
 }
 
 func (s *Swagger) createDefinition(t interface{}) {
-	generator := definition.NewDefinitionGenerator((*s).Definitions)
+	generator := definition.NewDefinitionGenerator((*s).Definitions, s.hidePackageName)
 	generator.CreateDefinition(t)
 }

--- a/generate_test.go
+++ b/generate_test.go
@@ -3,6 +3,7 @@ package swagno
 import (
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/go-swagno/swagno/components/definition"
@@ -115,9 +116,74 @@ func TestSwaggerGeneration(t *testing.T) {
 			got.AddEndpoints(tc.endpoints)
 			got.generateSwaggerJson()
 
-			if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Swagger{}, "endpoints"), cmpopts.IgnoreFields(definition.DefinitionProperties{}, "Example", "IsRequired")); diff != "" {
+			if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(Swagger{}, "endpoints", "hidePackageName"), cmpopts.IgnoreFields(definition.DefinitionProperties{}, "Example", "IsRequired")); diff != "" {
 				t.Errorf("JsonSwagger() mismatch (-expected +got):\n%s", diff)
 			}
 		})
 	}
+}
+
+// TestHidePackageName verifies that enabling Config.HidePackageName strips the
+// package qualifier from definition keys and $ref values (e.g. "models.ProductPost"
+// becomes "ProductPost"), while the default keeps the package-qualified names.
+func TestHidePackageName(t *testing.T) {
+	endpoints := []*endpoint.EndPoint{
+		endpoint.New(
+			endpoint.POST,
+			"/product",
+			endpoint.WithBody(models.ProductPost{}),
+			endpoint.WithSuccessfulReturns([]response.Response{response.New(models.SuccessfulResponse{}, "201", "Request Accepted")}),
+			endpoint.WithErrors([]response.Response{response.New([]models.UnsuccessfulResponse{}, "400", "Bad Request")}),
+		),
+	}
+
+	t.Run("hidden", func(t *testing.T) {
+		sw := New(Config{Title: "Testing API", Version: "v1.0.0", HidePackageName: true})
+		sw.AddEndpoints(endpoints)
+		doc := string(sw.MustToJson())
+
+		if strings.Contains(doc, "models.") {
+			t.Errorf("expected no package qualifier in output, but found \"models.\":\n%s", doc)
+		}
+		for _, want := range []string{
+			`"#/definitions/ProductPost"`,
+			`"#/definitions/SuccessfulResponse"`,
+			`"#/definitions/UnsuccessfulResponse"`,
+		} {
+			if !strings.Contains(doc, want) {
+				t.Errorf("expected output to contain %s, but it did not:\n%s", want, doc)
+			}
+		}
+
+		// definition keys must also be stripped so the refs resolve
+		var parsed struct {
+			Definitions map[string]json.RawMessage `json:"definitions"`
+		}
+		if err := json.Unmarshal([]byte(doc), &parsed); err != nil {
+			t.Fatal(err)
+		}
+		for _, key := range []string{"ProductPost", "SuccessfulResponse", "UnsuccessfulResponse"} {
+			if _, ok := parsed.Definitions[key]; !ok {
+				t.Errorf("expected definitions to contain key %q, got keys: %v", key, keysOf(parsed.Definitions))
+			}
+		}
+	})
+
+	t.Run("default keeps package name", func(t *testing.T) {
+		sw := New(Config{Title: "Testing API", Version: "v1.0.0"})
+		sw.AddEndpoints(endpoints)
+		doc := string(sw.MustToJson())
+
+		if !strings.Contains(doc, `"#/definitions/models.ProductPost"`) {
+			t.Errorf("expected default output to keep package qualifier \"models.ProductPost\":\n%s", doc)
+		}
+	})
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/swagger.go
+++ b/swagger.go
@@ -23,6 +23,7 @@ type Swagger struct {
 	Tags                []tag.Tag                                   `json:"tags,omitempty"`
 	SecurityDefinitions map[string]securityDefinition               `json:"securityDefinitions,omitempty"`
 	endpoints           []*endpoint.EndPoint
+	hidePackageName     bool
 }
 
 // Info represents the information about the API.
@@ -93,6 +94,9 @@ type Config struct {
 	License        *License // license information for the Swagger documentation
 	Contact        *Contact // contact information for the Swagger documentation
 	TermsOfService string   // term of service information for the Swagger documentation
+	// HidePackageName, when true, references models without their package qualifier
+	// in the generated documentation (e.g. "MyStruct" instead of "models.MyStruct").
+	HidePackageName bool
 }
 
 // buildSwagger creates a new swagger instance with the given title, version, and optional arguments.
@@ -125,6 +129,7 @@ func buildSwagger(c Config) (swagger *Swagger) {
 		Tags:                []tag.Tag{},
 		SecurityDefinitions: make(map[string]securityDefinition),
 		endpoints:           []*endpoint.EndPoint{},
+		hidePackageName:     c.HidePackageName,
 	}
 
 	return

--- a/v3/README.md
+++ b/v3/README.md
@@ -248,6 +248,34 @@ openapi.Tags[0].Extensions = extensions.Extensions{"x-display-name": "Users"}
 
 > Keys that do not start with `x-` are silently dropped at serialization time (per OpenAPI 3.0.3 §4.9). Values can be any JSON-serializable type.
 
+## Hiding the Package Name in Model References
+
+By default, models are referenced by their package-qualified name, so a `models.MyStruct`
+type appears in the documentation as `#/components/schemas/models.MyStruct`. Set
+`HidePackageName: true` on the `Config` to drop the package qualifier and reference the model
+as just `#/components/schemas/MyStruct`:
+
+```go
+openapi := swagno3.New(swagno3.Config{
+    Title:           "My API",
+    Version:         "v1.0.0",
+    HidePackageName: true,
+})
+```
+
+| `HidePackageName` | Reference in the generated docs       |
+| ----------------- | ------------------------------------- |
+| `false` (default) | `#/components/schemas/models.MyStruct` |
+| `true`            | `#/components/schemas/MyStruct`        |
+
+This also strips the package qualifier from the `Components.Schemas` map keys, so a
+post-generation lookup uses the short name (e.g. `openapi.Components.Schemas["Product"]`
+instead of `openapi.Components.Schemas["myapp.Product"]`).
+
+> **Note:** Enabling this option can cause collisions when two packages declare a type with
+> the same name (e.g. `models.User` and `dto.User` would both become `User`). Only enable it
+> when your model names are unique across packages.
+
 ## Components Structure
 
 The v3 package maintains the same modular structure as the original:

--- a/v3/components/definition/definition.go
+++ b/v3/components/definition/definition.go
@@ -141,20 +141,24 @@ func (ed ExternalDocs) MarshalJSON() ([]byte, error) {
 // of adding new schemas based on reflected types.
 type DefinitionGenerator struct {
 	Schemas map[string]Schema
+	// HidePackageName, when true, strips the leading package qualifier from
+	// schema names and $ref values (e.g. "models.MyStruct" -> "MyStruct").
+	HidePackageName bool
 }
 
 // NewDefinitionGenerator is a constructor function that initializes
 // a DefinitionGenerator with a provided map of Schema objects.
-func NewDefinitionGenerator(schemaMap map[string]Schema) *DefinitionGenerator {
+func NewDefinitionGenerator(schemaMap map[string]Schema, hidePackageName bool) *DefinitionGenerator {
 	return &DefinitionGenerator{
-		Schemas: schemaMap,
+		Schemas:         schemaMap,
+		HidePackageName: hidePackageName,
 	}
 }
 
 // CreateDefinition analyzes the type of the provided value 't' and adds a corresponding Schema to the generator's Schemas map.
 func (g DefinitionGenerator) CreateDefinition(t interface{}) {
 	properties := make(map[string]SchemaProperty)
-	definitionName := fmt.Sprintf("%T", t)
+	definitionName := fields.RefName(fmt.Sprintf("%T", t), g.HidePackageName)
 
 	reflectReturn := reflect.TypeOf(t)
 	switch reflectReturn.Kind() {
@@ -235,7 +239,7 @@ func (g DefinitionGenerator) createStructDefinitions(structType reflect.Type) ma
 					properties[fieldJsonTag] = SchemaProperty{
 						Type: fieldType,
 						Items: &SchemaItems{
-							Ref: fmt.Sprintf("#/components/schemas/%s", field.Type.Elem().Elem().String()),
+							Ref: fmt.Sprintf("#/components/schemas/%s", fields.RefName(field.Type.Elem().Elem().String(), g.HidePackageName)),
 						},
 						IsRequired:  g.isRequired(field),
 						Nullable:    field.Type.Kind() == reflect.Pointer,
@@ -263,7 +267,7 @@ func (g DefinitionGenerator) createStructDefinitions(structType reflect.Type) ma
 				properties[fieldJsonTag] = SchemaProperty{
 					Type: fieldType,
 					Items: &SchemaItems{
-						Ref: fmt.Sprintf("#/components/schemas/%s", field.Type.Elem().String()),
+						Ref: fmt.Sprintf("#/components/schemas/%s", fields.RefName(field.Type.Elem().String(), g.HidePackageName)),
 					},
 					IsRequired:  g.isRequired(field),
 					Example:     fields.ExampleTag(field),
@@ -293,7 +297,7 @@ func (g DefinitionGenerator) createStructDefinitions(structType reflect.Type) ma
 				properties[fieldJsonTag] = g.durationProperty(field, isRequiredField)
 			} else {
 				properties[fieldJsonTag] = SchemaProperty{
-					Ref:         fmt.Sprintf("#/components/schemas/%s", field.Type.String()),
+					Ref:         fmt.Sprintf("#/components/schemas/%s", fields.RefName(field.Type.String(), g.HidePackageName)),
 					IsRequired:  isRequiredField,
 					Example:     fields.ExampleTag(field),
 					Description: fields.DescriptionTag(field),
@@ -323,7 +327,7 @@ func (g DefinitionGenerator) createStructDefinitions(structType reflect.Type) ma
 					properties[fieldJsonTag] = SchemaProperty{
 						Type: fields.Type(field.Type.Elem().Kind().String()),
 						Items: &SchemaItems{
-							Ref: fmt.Sprintf("#/components/schemas/%s", field.Type.Elem().Elem().String()),
+							Ref: fmt.Sprintf("#/components/schemas/%s", fields.RefName(field.Type.Elem().Elem().String(), g.HidePackageName)),
 						},
 						Nullable:    true,
 						Example:     fields.ExampleTag(field),
@@ -354,7 +358,7 @@ func (g DefinitionGenerator) createStructDefinitions(structType reflect.Type) ma
 			}
 
 		case "map":
-			name := fmt.Sprintf("%s.%s", structType.String(), fieldJsonTag)
+			name := fmt.Sprintf("%s.%s", fields.RefName(structType.String(), g.HidePackageName), fieldJsonTag)
 			mapKeyType := field.Type.Key()
 			mapValueType := field.Type.Elem()
 			if mapValueType.Kind() == reflect.Ptr {
@@ -370,7 +374,7 @@ func (g DefinitionGenerator) createStructDefinitions(structType reflect.Type) ma
 					Type: "object",
 					Properties: map[string]SchemaProperty{
 						fields.Type(mapKeyType.String()): {
-							Ref:         fmt.Sprintf("#/components/schemas/%s", mapValueType.String()),
+							Ref:         fmt.Sprintf("#/components/schemas/%s", fields.RefName(mapValueType.String(), g.HidePackageName)),
 							Example:     fields.ExampleTag(field),
 							Description: fields.DescriptionTag(field),
 						},
@@ -430,7 +434,7 @@ func (g DefinitionGenerator) durationProperty(field reflect.StructField, require
 
 func (g DefinitionGenerator) refProperty(field reflect.StructField, required bool) SchemaProperty {
 	return SchemaProperty{
-		Ref:         fmt.Sprintf("#/components/schemas/%s", field.Type.Elem().String()),
+		Ref:         fmt.Sprintf("#/components/schemas/%s", fields.RefName(field.Type.Elem().String(), g.HidePackageName)),
 		IsRequired:  required,
 		Nullable:    true,
 		Example:     fields.ExampleTag(field),

--- a/v3/components/endpoint/endpoints.go
+++ b/v3/components/endpoint/endpoints.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 
 	"github.com/go-swagno/swagno/v3/components/extensions"
+	"github.com/go-swagno/swagno/v3/components/fields"
 	"github.com/go-swagno/swagno/v3/components/http/response"
 	"github.com/go-swagno/swagno/v3/components/mime"
 	"github.com/go-swagno/swagno/v3/components/parameter"
@@ -244,9 +245,9 @@ func (e *EndPoint) Path() string {
 
 // BodyJsonParameter creates the request body parameter for OpenAPI 3.0.
 // In OpenAPI 3.0, request bodies are handled differently than in Swagger 2.0
-func (e *EndPoint) BodyJsonParameter() *parameter.JsonParameter {
+func (e *EndPoint) BodyJsonParameter(hidePackageName bool) *parameter.JsonParameter {
 	if e.Body.Content != nil {
-		bodyRef := fmt.Sprintf("#/components/schemas/%T", e.Body.Content)
+		bodyRef := fmt.Sprintf("#/components/schemas/%s", fields.RefName(fmt.Sprintf("%T", e.Body.Content), hidePackageName))
 		bodySchema := parameter.JsonResponseSchema{
 			Ref: bodyRef,
 		}
@@ -255,7 +256,7 @@ func (e *EndPoint) BodyJsonParameter() *parameter.JsonParameter {
 			bodySchema = parameter.JsonResponseSchema{
 				Type: "array",
 				Items: &parameter.JsonResponseSchemeItems{
-					Ref: fmt.Sprintf("#/components/schemas/%T", e.Body.Content),
+					Ref: fmt.Sprintf("#/components/schemas/%s", fields.RefName(fmt.Sprintf("%T", e.Body.Content), hidePackageName)),
 				},
 			}
 		}

--- a/v3/components/fields/parsing.go
+++ b/v3/components/fields/parsing.go
@@ -53,6 +53,20 @@ func IsRequired(field reflect.StructField) bool {
 	return tagValue == "true"
 }
 
+// RefName returns the type name with its leading package qualifier removed when
+// hidePackage is true (e.g. "models.MyStruct" -> "MyStruct"). It is a no-op when
+// hidePackage is false. Synthetic names such as "models.Product.metadata" become
+// "Product.metadata", since only the leading package segment is stripped.
+func RefName(name string, hidePackage bool) string {
+	if !hidePackage {
+		return name
+	}
+	if _, after, found := strings.Cut(name, "."); found {
+		return after
+	}
+	return name
+}
+
 // Type maps a string to its corresponding OpenAPI type according to the
 // OpenAPI Specification version 3.0.3 data types (https://spec.openapis.org/oas/v3.0.3#data-types).
 func Type(t string) string {

--- a/v3/components/http/response/response.go
+++ b/v3/components/http/response/response.go
@@ -25,7 +25,11 @@ type CustomResponse struct {
 }
 
 // ResponseGenerator is a struct that provides functionality to generate response schemas.
-type ResponseGenerator struct{}
+type ResponseGenerator struct {
+	// HidePackageName, when true, strips the leading package qualifier from $ref
+	// values (e.g. "models.MyStruct" -> "MyStruct").
+	HidePackageName bool
+}
 
 // New creates a new instance of Response with the provided model return code, and description.
 func New(model any, returnCode string, description string) CustomResponse {
@@ -61,8 +65,10 @@ func (c CustomResponse) Examples() map[string]interface{} {
 }
 
 // NewResponseGenerator creates a new instance of ResponseGenerator.
-func NewResponseGenerator() *ResponseGenerator {
-	return &ResponseGenerator{}
+func NewResponseGenerator(hidePackageName bool) *ResponseGenerator {
+	return &ResponseGenerator{
+		HidePackageName: hidePackageName,
+	}
 }
 
 // Generate generates a JSON response schema based on the provided model for OpenAPI 3.0.
@@ -76,7 +82,7 @@ func (g ResponseGenerator) Generate(model any) *parameter.JsonResponseSchema {
 			return &parameter.JsonResponseSchema{
 				Type: "array",
 				Items: &parameter.JsonResponseSchemeItems{
-					Ref: strings.ReplaceAll(fmt.Sprintf("#/components/schemas/%s", reflect.TypeOf(model).Elem().String()), "[]", ""),
+					Ref: fmt.Sprintf("#/components/schemas/%s", fields.RefName(strings.ReplaceAll(reflect.TypeOf(model).Elem().String(), "[]", ""), g.HidePackageName)),
 				},
 			}
 		} else {
@@ -89,7 +95,7 @@ func (g ResponseGenerator) Generate(model any) *parameter.JsonResponseSchema {
 		}
 
 	case reflect.Map:
-		ref := strings.ReplaceAll(fmt.Sprintf("#/components/schemas/%T", model), "[]", "")
+		ref := fmt.Sprintf("#/components/schemas/%s", fields.RefName(strings.ReplaceAll(fmt.Sprintf("%T", model), "[]", ""), g.HidePackageName))
 		return &parameter.JsonResponseSchema{
 			Ref: ref,
 		}
@@ -97,7 +103,7 @@ func (g ResponseGenerator) Generate(model any) *parameter.JsonResponseSchema {
 	default:
 		if hasStructFields(model) {
 			return &parameter.JsonResponseSchema{
-				Ref: strings.ReplaceAll(fmt.Sprintf("#/components/schemas/%T", model), "[]", ""),
+				Ref: fmt.Sprintf("#/components/schemas/%s", fields.RefName(strings.ReplaceAll(fmt.Sprintf("%T", model), "[]", ""), g.HidePackageName)),
 			}
 		}
 	}

--- a/v3/docs/02-core-modules.md
+++ b/v3/docs/02-core-modules.md
@@ -84,17 +84,18 @@ openapi.AddServer("https://staging.example.com/v1", "Staging server")
 
 ```go
 type Config struct {
-    Title          string                // Title of the OpenAPI documentation
-    Version        string                // API version
-    Summary        string                // API summary (OpenAPI 3.0 feature)
-    Description    string                // API description
-    Servers        []Server              // Server configurations
-    License        *License              // License information
-    Contact        *Contact              // Contact information
-    TermsOfService string                // Terms of service
-    ExternalDocs   *ExternalDocs         // External documentation
-    Extensions     extensions.Extensions // root-level OpenAPI extensions (x-*)
-    InfoExtensions extensions.Extensions // extensions on the Info object (x-*)
+    Title           string                // Title of the OpenAPI documentation
+    Version         string                // API version
+    Summary         string                // API summary (OpenAPI 3.0 feature)
+    Description     string                // API description
+    Servers         []Server              // Server configurations
+    License         *License              // License information
+    Contact         *Contact              // Contact information
+    TermsOfService  string                // Terms of service
+    ExternalDocs    *ExternalDocs         // External documentation
+    Extensions      extensions.Extensions // root-level OpenAPI extensions (x-*)
+    InfoExtensions  extensions.Extensions // extensions on the Info object (x-*)
+    HidePackageName bool                  // reference models without their package qualifier (e.g. "MyStruct" instead of "models.MyStruct")
 }
 ```
 

--- a/v3/docs/05-api-reference.md
+++ b/v3/docs/05-api-reference.md
@@ -126,19 +126,26 @@ Configuration structure for creating OpenAPI instances.
 
 ```go
 type Config struct {
-    Title          string                // API title (required)
-    Version        string                // API version (required)
-    Summary        string                // API summary
-    Description    string                // API description
-    Servers        []Server              // Server configurations
-    License        *License              // License information
-    Contact        *Contact              // Contact information
-    TermsOfService string                // Terms of service URL
-    ExternalDocs   *ExternalDocs         // External documentation
-    Extensions     extensions.Extensions // Root-level OpenAPI extensions (x-*)
-    InfoExtensions extensions.Extensions // Extensions on the Info object (x-*)
+    Title           string                // API title (required)
+    Version         string                // API version (required)
+    Summary         string                // API summary
+    Description     string                // API description
+    Servers         []Server              // Server configurations
+    License         *License              // License information
+    Contact         *Contact              // Contact information
+    TermsOfService  string                // Terms of service URL
+    ExternalDocs    *ExternalDocs         // External documentation
+    Extensions      extensions.Extensions // Root-level OpenAPI extensions (x-*)
+    InfoExtensions  extensions.Extensions // Extensions on the Info object (x-*)
+    HidePackageName bool                  // reference models without their package qualifier (e.g. "MyStruct" instead of "models.MyStruct")
 }
 ```
+
+When `HidePackageName` is `true`, schema keys and `$ref` values omit the package
+qualifier — `#/components/schemas/models.MyStruct` becomes `#/components/schemas/MyStruct`.
+It defaults to `false`, preserving the package-qualified names. Enable it only when model
+names are unique across packages, since stripping the package can otherwise cause name
+collisions.
 
 ### `Contact`
 

--- a/v3/generate.go
+++ b/v3/generate.go
@@ -12,8 +12,8 @@ import (
 	"github.com/go-swagno/swagno/v3/components/parameter"
 )
 
-func appendResponses(sourceResponses map[string]endpoint.JsonResponse, additionalResponses []response.Response) map[string]endpoint.JsonResponse {
-	responseGenerator := response.NewResponseGenerator()
+func appendResponses(sourceResponses map[string]endpoint.JsonResponse, additionalResponses []response.Response, hidePackageName bool) map[string]endpoint.JsonResponse {
+	responseGenerator := response.NewResponseGenerator(hidePackageName)
 
 	for _, resp := range additionalResponses {
 		var responseSchema *parameter.JsonResponseSchema
@@ -107,8 +107,8 @@ func (o *OpenAPI) generateOpenAPIJson() {
 
 		// Creates the schema definition for all successful return and error objects, and then links them in the responses section
 		responses := map[string]endpoint.JsonResponse{}
-		responses = appendResponses(responses, e.SuccessfulReturns())
-		responses = appendResponses(responses, e.Errors())
+		responses = appendResponses(responses, e.SuccessfulReturns(), o.hidePackageName)
+		responses = appendResponses(responses, e.Errors(), o.hidePackageName)
 
 		// add each endpoint to paths field of OpenAPI
 		je := e.AsJson()
@@ -126,7 +126,7 @@ func (o *OpenAPI) generateOpenAPIJson() {
 		}
 
 		// Handle request body for OpenAPI 3.0
-		if bjp := e.BodyJsonParameter(); bjp != nil {
+		if bjp := e.BodyJsonParameter(o.hidePackageName); bjp != nil {
 			// Support multiple content types for request body
 			content := map[string]endpoint.MediaType{}
 
@@ -234,7 +234,7 @@ func (o *OpenAPI) createDefinition(t interface{}) {
 		o.Components.Schemas = make(map[string]definition.Schema)
 	}
 
-	generator := definition.NewDefinitionGenerator(o.Components.Schemas)
+	generator := definition.NewDefinitionGenerator(o.Components.Schemas, o.hidePackageName)
 	generator.CreateDefinition(t)
 }
 

--- a/v3/generate_test.go
+++ b/v3/generate_test.go
@@ -116,7 +116,7 @@ func TestSwaggerGeneration(t *testing.T) {
 				got,
 				cmpopts.EquateEmpty(),
 				cmpopts.SortSlices(func(a, b string) bool { return a < b }),
-				cmpopts.IgnoreFields(OpenAPI{}, "endpoints"),
+				cmpopts.IgnoreFields(OpenAPI{}, "endpoints", "hidePackageName"),
 				cmpopts.IgnoreFields(definition.SchemaProperty{}, "IsRequired"),
 				cmpopts.IgnoreFields(endpoint.JsonEndPoint{}, "Consume", "Produce"),
 			); diff != "" {

--- a/v3/openapi.go
+++ b/v3/openapi.go
@@ -26,7 +26,8 @@ type OpenAPI struct {
 	ExternalDocs *ExternalDocs                `json:"externalDocs,omitempty"`
 	Extensions   extensions.Extensions        `json:"-"`
 
-	endpoints []*endpoint.EndPoint
+	endpoints       []*endpoint.EndPoint
+	hidePackageName bool
 }
 
 func (o OpenAPI) MarshalJSON() ([]byte, error) {
@@ -195,6 +196,9 @@ type Config struct {
 	ExternalDocs   *ExternalDocs         // external documentation
 	Extensions     extensions.Extensions // root-level OpenAPI extensions (x-*)
 	InfoExtensions extensions.Extensions // extensions on the Info object (x-*)
+	// HidePackageName, when true, references models without their package qualifier
+	// in the generated documentation (e.g. "MyStruct" instead of "models.MyStruct").
+	HidePackageName bool
 }
 
 // buildOpenAPI creates a new OpenAPI instance with the given configuration.
@@ -226,8 +230,9 @@ func buildOpenAPI(c Config) (openapi *OpenAPI) {
 			Schemas:         make(map[string]definition.Schema),
 			SecuritySchemes: make(map[security.SecuritySchemeName]SecurityScheme),
 		},
-		Tags:      []tag.Tag{},
-		endpoints: []*endpoint.EndPoint{},
+		Tags:            []tag.Tag{},
+		endpoints:       []*endpoint.EndPoint{},
+		hidePackageName: c.HidePackageName,
 	}
 
 	// Set default server if none provided and none will be added later

--- a/v3/openapi_test.go
+++ b/v3/openapi_test.go
@@ -275,3 +275,69 @@ func TestMultipleServers(t *testing.T) {
 		t.Errorf("First server description is incorrect")
 	}
 }
+
+// TestHidePackageNameV3 verifies that enabling Config.HidePackageName strips the
+// package qualifier from schema keys and $ref values (e.g. "swagno3.TestUser"
+// becomes "TestUser"), while the default keeps the package-qualified names.
+func TestHidePackageNameV3(t *testing.T) {
+	buildEndpoint := func() *endpoint.EndPoint {
+		return endpoint.New(
+			endpoint.POST,
+			"/users",
+			endpoint.WithBody(TestUser{}),
+			endpoint.WithSuccessfulReturns([]response.Response{
+				response.New(TestUser{}, "201", "User created"),
+			}),
+			endpoint.WithErrors([]response.Response{
+				response.New([]TestError{}, "400", "Bad Request"),
+			}),
+		)
+	}
+
+	t.Run("hidden", func(t *testing.T) {
+		openapi := New(Config{Title: "Test API", Version: "v1.0.0", HidePackageName: true})
+		openapi.AddEndpoint(buildEndpoint())
+		doc := string(openapi.MustToJson())
+
+		if strings.Contains(doc, "swagno3.") {
+			t.Errorf("expected no package qualifier in output, but found \"swagno3.\":\n%s", doc)
+		}
+		for _, want := range []string{
+			`"#/components/schemas/TestUser"`,
+			`"#/components/schemas/TestError"`,
+		} {
+			if !strings.Contains(doc, want) {
+				t.Errorf("expected output to contain %s, but it did not:\n%s", want, doc)
+			}
+		}
+
+		// schema keys must also be stripped so the refs resolve
+		var parsed struct {
+			Components struct {
+				Schemas map[string]json.RawMessage `json:"schemas"`
+			} `json:"components"`
+		}
+		if err := json.Unmarshal([]byte(doc), &parsed); err != nil {
+			t.Fatal(err)
+		}
+		for _, key := range []string{"TestUser", "TestError"} {
+			if _, ok := parsed.Components.Schemas[key]; !ok {
+				keys := make([]string, 0, len(parsed.Components.Schemas))
+				for k := range parsed.Components.Schemas {
+					keys = append(keys, k)
+				}
+				t.Errorf("expected schemas to contain key %q, got keys: %v", key, keys)
+			}
+		}
+	})
+
+	t.Run("default keeps package name", func(t *testing.T) {
+		openapi := New(Config{Title: "Test API", Version: "v1.0.0"})
+		openapi.AddEndpoint(buildEndpoint())
+		doc := string(openapi.MustToJson())
+
+		if !strings.Contains(doc, `"#/components/schemas/swagno3.TestUser"`) {
+			t.Errorf("expected default output to keep package qualifier \"swagno3.TestUser\":\n%s", doc)
+		}
+	})
+}


### PR DESCRIPTION
## Add `HidePackageName` config option

  Closes #49

Models are currently referenced by their package-qualified name in the generated docs (e.g. `models.MyStruct`). As requested in #49, this PR adds an opt-in `HidePackageName` flag to `Config` that strips the package qualifier so references become just `MyStruct`.

  It is implemented symmetrically for both v2 (Swagger 2.0) and v3 (OpenAPI 3.0).
  The flag defaults to `false`, so existing behavior is unchanged and the existing tests pass untouched.

  ### Usage

  **v2 (Swagger 2.0)**
  ```go
  sw := swagno.New(swagno.Config{
      Title:           "My API",
      Version:         "v1.0.0",
      HidePackageName: true,
  })
  // $ref: "#/definitions/MyStruct"  (was "#/definitions/models.MyStruct")

  v3 (OpenAPI 3.0)
  openapi := swagno3.New(swagno3.Config{
      Title:           "My API",
      Version:         "v1.0.0",
      HidePackageName: true,
  })  
  // $ref: "#/components/schemas/MyStruct"  (was "#/components/schemas/models.MyStruct")

  When enabled, both the $ref values and the definition/schema map keys drop the
  package prefix, so references still resolve.

  Notes

  - Enabling this can cause collisions when two packages declare a type with the same name (e.g. models.User and dto.User both become User); documented as a caveat.
  - New tests added for both versions (TestHidePackageName, TestHidePackageNameV3) covering the enabled case and a default control case.
  - Docs updated (README + v3 README + API reference / core-modules docs).