### PR TITLE
Return error for struct name collisions when HidePackageName enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,8 +275,10 @@ sw := swagno.New(swagno.Config{Title: "Testing API", Version: "v1.0.0", HidePack
 | `true`            | `#/definitions/MyStruct`        |
 
 > **Note:** Enabling this option can cause collisions when two packages declare a type with
-> the same name (e.g. `models.User` and `dto.User` would both become `User`). Only enable it
-> when your model names are unique across packages.
+> the same name (e.g. `models.User` and `dto.User` would both become `User`). Such a collision
+> is **not** silently resolved: `ToJson()` returns a `*NameCollisionError` (and `MustToJson()`
+> panics) listing the colliding name and the conflicting types. Rename one of the types or keep
+> `HidePackageName` disabled to fix it.
 
 The same option is available on the v3 `swagno3.Config` and affects
 `#/components/schemas/...` references.

--- a/collision.go
+++ b/collision.go
@@ -1,0 +1,60 @@
+package swagno
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// NameCollisionError is returned by ToJson (and panicked by MustToJson) when the
+// HidePackageName option causes two or more distinct, package-qualified types to
+// map to the same stripped name. The generated document would otherwise silently
+// drop one of the colliding schemas, so generation fails instead.
+type NameCollisionError struct {
+	// Collisions maps each colliding stripped name to the sorted list of full
+	// (package-qualified) type names that produced it.
+	Collisions map[string][]string
+}
+
+func (e *NameCollisionError) Error() string {
+	shortNames := make([]string, 0, len(e.Collisions))
+	for name := range e.Collisions {
+		shortNames = append(shortNames, name)
+	}
+	sort.Strings(shortNames)
+
+	parts := make([]string, 0, len(shortNames))
+	for _, name := range shortNames {
+		parts = append(parts, fmt.Sprintf("%q maps to multiple types [%s]", name, strings.Join(e.Collisions[name], ", ")))
+	}
+
+	return fmt.Sprintf(
+		"swagno: HidePackageName name collision: %s; rename one of the types or set HidePackageName to false",
+		strings.Join(parts, "; "),
+	)
+}
+
+// collisionError inspects the recorded stripped-name -> full-type-name sets and
+// returns a *NameCollisionError if any stripped name was produced by more than one
+// distinct type. It returns nil when there are no collisions.
+func collisionError(definitionTypeNames map[string]map[string]struct{}) error {
+	var collisions map[string][]string
+	for shortName, fullNames := range definitionTypeNames {
+		if len(fullNames) < 2 {
+			continue
+		}
+		names := make([]string, 0, len(fullNames))
+		for fullName := range fullNames {
+			names = append(names, fullName)
+		}
+		sort.Strings(names)
+		if collisions == nil {
+			collisions = map[string][]string{}
+		}
+		collisions[shortName] = names
+	}
+	if collisions == nil {
+		return nil
+	}
+	return &NameCollisionError{Collisions: collisions}
+}

--- a/components/definition/definition.go
+++ b/components/definition/definition.go
@@ -45,21 +45,43 @@ type DefinitionGenerator struct {
 	// HidePackageName, when true, strips the leading package qualifier from
 	// definition names and $ref values (e.g. "models.MyStruct" -> "MyStruct").
 	HidePackageName bool
+	// DefinitionTypeNames records, per stripped definition name, the set of full
+	// (package-qualified) type names that produced it. It is used to detect
+	// collisions when HidePackageName is enabled. The map is shared across
+	// generator instances so it accumulates across all definitions of a document.
+	DefinitionTypeNames map[string]map[string]struct{}
 }
 
 // NewDefinitionGenerator is a constructor function that initializes
 // a DefinitionGenerator with a provided map of Definition objects.
-func NewDefinitionGenerator(definitionMap map[string]Definition, hidePackageName bool) *DefinitionGenerator {
+func NewDefinitionGenerator(definitionMap map[string]Definition, hidePackageName bool, definitionTypeNames map[string]map[string]struct{}) *DefinitionGenerator {
 	return &DefinitionGenerator{
-		Definitions:     definitionMap,
-		HidePackageName: hidePackageName,
+		Definitions:         definitionMap,
+		HidePackageName:     hidePackageName,
+		DefinitionTypeNames: definitionTypeNames,
 	}
+}
+
+// recordName tracks that the stripped definition name shortName was produced by
+// the full (package-qualified) type name fullName. It is a no-op unless
+// HidePackageName is enabled, since collisions can only arise from stripping.
+func (g DefinitionGenerator) recordName(shortName, fullName string) {
+	if !g.HidePackageName || g.DefinitionTypeNames == nil {
+		return
+	}
+	set, ok := g.DefinitionTypeNames[shortName]
+	if !ok {
+		set = map[string]struct{}{}
+		g.DefinitionTypeNames[shortName] = set
+	}
+	set[fullName] = struct{}{}
 }
 
 // CreateDefinition analyzes the type of the provided value 't' and adds a corresponding Definition to the generator's Definitions map.
 func (g DefinitionGenerator) CreateDefinition(t interface{}) {
 	properties := make(map[string]DefinitionProperties)
-	definitionName := fields.RefName(fmt.Sprintf("%T", t), g.HidePackageName)
+	fullName := fmt.Sprintf("%T", t)
+	definitionName := fields.RefName(fullName, g.HidePackageName)
 
 	reflectReturn := reflect.TypeOf(t)
 	switch reflectReturn.Kind() {
@@ -69,6 +91,7 @@ func (g DefinitionGenerator) CreateDefinition(t interface{}) {
 			properties = g.createStructDefinitions(reflectReturn)
 		}
 		definitionName, _ = strings.CutPrefix(definitionName, "[]")
+		fullName, _ = strings.CutPrefix(fullName, "[]")
 	case reflect.Struct:
 		if reflectReturn == reflect.TypeOf(response.CustomResponse{}) {
 			// if CustomResponseType, use Model struct in it
@@ -84,6 +107,7 @@ func (g DefinitionGenerator) CreateDefinition(t interface{}) {
 	// delete empty json tags
 	delete(properties, "")
 
+	g.recordName(definitionName, fullName)
 	g.Definitions[definitionName] = Definition{
 		Type:       "object",
 		Properties: properties,
@@ -246,6 +270,7 @@ func (g DefinitionGenerator) createStructDefinitions(structType reflect.Type) ma
 
 		case "map":
 			name := fmt.Sprintf("%s.%s", fields.RefName(structType.String(), g.HidePackageName), fieldJsonTag)
+			g.recordName(name, fmt.Sprintf("%s.%s", structType.String(), fieldJsonTag))
 			mapKeyType := field.Type.Key()
 			mapValueType := field.Type.Elem()
 			if mapValueType.Kind() == reflect.Ptr {

--- a/docs/05-api-reference.md
+++ b/docs/05-api-reference.md
@@ -235,8 +235,9 @@ type Config struct {
 
 When `HidePackageName` is `true`, definition keys and `$ref` values omit the package
 qualifier — `#/definitions/models.MyStruct` becomes `#/definitions/MyStruct`. It defaults to
-`false`, preserving the package-qualified names. Enable it only when model names are unique
-across packages, since stripping the package can otherwise cause name collisions.
+`false`, preserving the package-qualified names. If two types from different packages strip to
+the same name, `ToJson()` returns a `*NameCollisionError` (and `MustToJson()` panics) rather
+than silently overwriting one schema; rename one type or disable the option.
 
 #### `Info`
 

--- a/generate.go
+++ b/generate.go
@@ -34,14 +34,16 @@ func appendResponses(sourceResponses map[string]endpoint.JsonResponse, additiona
 	return sourceResponses
 }
 
-func (s *Swagger) generateSwaggerJson() {
+func (s *Swagger) generateSwaggerJson() error {
 	if len(s.endpoints) == 0 {
 		log.Println("No endpoints found")
-		return
+		return nil
 	}
 
 	// generate definition object of swagger json: https://swagger.io/specification/v2/#definitions-object
-	s.generateSwaggerDefinition()
+	if err := s.generateSwaggerDefinition(); err != nil {
+		return err
+	}
 
 	// convert all user EndPoint models to 'path' fields of swagger json
 	// https://swagger.io/specification/v2/#paths-object
@@ -86,18 +88,25 @@ func (s *Swagger) generateSwaggerJson() {
 		je.Responses = responses
 		s.Paths[path][method] = je
 	}
+
+	return nil
 }
 
 // ToJSON converts the Swagger object into its JSON representation formatted as bytes.
 // It returns a slice of bytes containing the Swagger documentation in JSON format.
 func (s *Swagger) ToJson() (jsonDocs []byte, err error) {
-	s.generateSwaggerJson()
+	if err := s.generateSwaggerJson(); err != nil {
+		return nil, err
+	}
 	return json.MarshalIndent(s, "", "  ")
 }
 
 // MustToJson same thing as ToJson except for it doesn't return an error.
+// It panics if a name collision is detected while generating the document.
 func (s Swagger) MustToJson() (jsonDocs []byte) {
-	s.generateSwaggerJson()
+	if err := s.generateSwaggerJson(); err != nil {
+		panic(err)
+	}
 
 	json, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {
@@ -108,23 +117,28 @@ func (s Swagger) MustToJson() (jsonDocs []byte) {
 }
 
 // generate "definitions" keys from endpoints: https://swagger.io/specification/v2/#definitions-object
-func (s *Swagger) generateSwaggerDefinition() {
+// It returns a *NameCollisionError when HidePackageName causes two distinct types
+// to map to the same stripped definition name.
+func (s *Swagger) generateSwaggerDefinition() error {
+	// shared across all createDefinition calls so collisions are detected document-wide
+	definitionTypeNames := map[string]map[string]struct{}{}
 	for _, endpoint := range s.endpoints {
 		if endpoint.Body.Content != nil {
-			s.createDefinition(endpoint.Body.Content)
+			s.createDefinition(endpoint.Body.Content, definitionTypeNames)
 		}
-		s.createDefinitions(endpoint.SuccessfulReturns())
-		s.createDefinitions(endpoint.Errors())
+		s.createDefinitions(endpoint.SuccessfulReturns(), definitionTypeNames)
+		s.createDefinitions(endpoint.Errors(), definitionTypeNames)
 	}
+	return collisionError(definitionTypeNames)
 }
 
-func (s *Swagger) createDefinitions(r []response.Response) {
+func (s *Swagger) createDefinitions(r []response.Response, definitionTypeNames map[string]map[string]struct{}) {
 	for _, obj := range r {
-		s.createDefinition(obj)
+		s.createDefinition(obj, definitionTypeNames)
 	}
 }
 
-func (s *Swagger) createDefinition(t interface{}) {
-	generator := definition.NewDefinitionGenerator((*s).Definitions, s.hidePackageName)
+func (s *Swagger) createDefinition(t interface{}, definitionTypeNames map[string]map[string]struct{}) {
+	generator := definition.NewDefinitionGenerator((*s).Definitions, s.hidePackageName, definitionTypeNames)
 	generator.CreateDefinition(t)
 }

--- a/generate_test.go
+++ b/generate_test.go
@@ -2,6 +2,7 @@ package swagno
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -186,4 +187,67 @@ func keysOf(m map[string]json.RawMessage) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// SuccessfulResponse is a deliberate name twin of models.SuccessfulResponse, declared
+// in this (swagno) package, so that enabling HidePackageName makes both strip to the
+// same "SuccessfulResponse" name and triggers a collision.
+type SuccessfulResponse struct {
+	Status string `json:"status"`
+}
+
+// TestHidePackageNameCollision verifies that when HidePackageName strips two distinct
+// types from different packages to the same name, generation fails with a
+// *NameCollisionError instead of silently dropping one of the schemas.
+func TestHidePackageNameCollision(t *testing.T) {
+	collidingEndpoints := []*endpoint.EndPoint{
+		endpoint.New(
+			endpoint.GET,
+			"/a",
+			endpoint.WithSuccessfulReturns([]response.Response{response.New(models.SuccessfulResponse{}, "200", "OK")}),
+		),
+		endpoint.New(
+			endpoint.GET,
+			"/b",
+			endpoint.WithSuccessfulReturns([]response.Response{response.New(SuccessfulResponse{}, "200", "OK")}),
+		),
+	}
+
+	t.Run("ToJson returns NameCollisionError", func(t *testing.T) {
+		sw := New(Config{Title: "Testing API", Version: "v1.0.0", HidePackageName: true})
+		sw.AddEndpoints(collidingEndpoints)
+
+		_, err := sw.ToJson()
+		if err == nil {
+			t.Fatal("expected a collision error, got nil")
+		}
+		var collisionErr *NameCollisionError
+		if !errors.As(err, &collisionErr) {
+			t.Fatalf("expected *NameCollisionError, got %T: %v", err, err)
+		}
+		if _, ok := collisionErr.Collisions["SuccessfulResponse"]; !ok {
+			t.Errorf("expected collision on %q, got %v", "SuccessfulResponse", collisionErr.Collisions)
+		}
+	})
+
+	t.Run("MustToJson panics", func(t *testing.T) {
+		sw := New(Config{Title: "Testing API", Version: "v1.0.0", HidePackageName: true})
+		sw.AddEndpoints(collidingEndpoints)
+
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected MustToJson to panic on collision, but it did not")
+			}
+		}()
+		sw.MustToJson()
+	})
+
+	t.Run("no collision when HidePackageName is disabled", func(t *testing.T) {
+		sw := New(Config{Title: "Testing API", Version: "v1.0.0"})
+		sw.AddEndpoints(collidingEndpoints)
+
+		if _, err := sw.ToJson(); err != nil {
+			t.Fatalf("expected no error with HidePackageName disabled, got %v", err)
+		}
+	})
 }

--- a/v3/README.md
+++ b/v3/README.md
@@ -273,8 +273,10 @@ post-generation lookup uses the short name (e.g. `openapi.Components.Schemas["Pr
 instead of `openapi.Components.Schemas["myapp.Product"]`).
 
 > **Note:** Enabling this option can cause collisions when two packages declare a type with
-> the same name (e.g. `models.User` and `dto.User` would both become `User`). Only enable it
-> when your model names are unique across packages.
+> the same name (e.g. `models.User` and `dto.User` would both become `User`). Such a collision
+> is **not** silently resolved: `ToJson()` returns a `*NameCollisionError` (and `MustToJson()`
+> panics) listing the colliding name and the conflicting types. Rename one of the types or keep
+> `HidePackageName` disabled to fix it.
 
 ## Components Structure
 

--- a/v3/collision.go
+++ b/v3/collision.go
@@ -1,0 +1,60 @@
+package swagno3
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// NameCollisionError is returned by ToJson (and panicked by MustToJson) when the
+// HidePackageName option causes two or more distinct, package-qualified types to
+// map to the same stripped name. The generated document would otherwise silently
+// drop one of the colliding schemas, so generation fails instead.
+type NameCollisionError struct {
+	// Collisions maps each colliding stripped name to the sorted list of full
+	// (package-qualified) type names that produced it.
+	Collisions map[string][]string
+}
+
+func (e *NameCollisionError) Error() string {
+	shortNames := make([]string, 0, len(e.Collisions))
+	for name := range e.Collisions {
+		shortNames = append(shortNames, name)
+	}
+	sort.Strings(shortNames)
+
+	parts := make([]string, 0, len(shortNames))
+	for _, name := range shortNames {
+		parts = append(parts, fmt.Sprintf("%q maps to multiple types [%s]", name, strings.Join(e.Collisions[name], ", ")))
+	}
+
+	return fmt.Sprintf(
+		"swagno: HidePackageName name collision: %s; rename one of the types or set HidePackageName to false",
+		strings.Join(parts, "; "),
+	)
+}
+
+// collisionError inspects the recorded stripped-name -> full-type-name sets and
+// returns a *NameCollisionError if any stripped name was produced by more than one
+// distinct type. It returns nil when there are no collisions.
+func collisionError(definitionTypeNames map[string]map[string]struct{}) error {
+	var collisions map[string][]string
+	for shortName, fullNames := range definitionTypeNames {
+		if len(fullNames) < 2 {
+			continue
+		}
+		names := make([]string, 0, len(fullNames))
+		for fullName := range fullNames {
+			names = append(names, fullName)
+		}
+		sort.Strings(names)
+		if collisions == nil {
+			collisions = map[string][]string{}
+		}
+		collisions[shortName] = names
+	}
+	if collisions == nil {
+		return nil
+	}
+	return &NameCollisionError{Collisions: collisions}
+}

--- a/v3/components/definition/definition.go
+++ b/v3/components/definition/definition.go
@@ -144,21 +144,43 @@ type DefinitionGenerator struct {
 	// HidePackageName, when true, strips the leading package qualifier from
 	// schema names and $ref values (e.g. "models.MyStruct" -> "MyStruct").
 	HidePackageName bool
+	// DefinitionTypeNames records, per stripped schema name, the set of full
+	// (package-qualified) type names that produced it. It is used to detect
+	// collisions when HidePackageName is enabled. The map is shared across
+	// generator instances so it accumulates across all schemas of a document.
+	DefinitionTypeNames map[string]map[string]struct{}
 }
 
 // NewDefinitionGenerator is a constructor function that initializes
 // a DefinitionGenerator with a provided map of Schema objects.
-func NewDefinitionGenerator(schemaMap map[string]Schema, hidePackageName bool) *DefinitionGenerator {
+func NewDefinitionGenerator(schemaMap map[string]Schema, hidePackageName bool, definitionTypeNames map[string]map[string]struct{}) *DefinitionGenerator {
 	return &DefinitionGenerator{
-		Schemas:         schemaMap,
-		HidePackageName: hidePackageName,
+		Schemas:             schemaMap,
+		HidePackageName:     hidePackageName,
+		DefinitionTypeNames: definitionTypeNames,
 	}
+}
+
+// recordName tracks that the stripped schema name shortName was produced by the
+// full (package-qualified) type name fullName. It is a no-op unless HidePackageName
+// is enabled, since collisions can only arise from stripping.
+func (g DefinitionGenerator) recordName(shortName, fullName string) {
+	if !g.HidePackageName || g.DefinitionTypeNames == nil {
+		return
+	}
+	set, ok := g.DefinitionTypeNames[shortName]
+	if !ok {
+		set = map[string]struct{}{}
+		g.DefinitionTypeNames[shortName] = set
+	}
+	set[fullName] = struct{}{}
 }
 
 // CreateDefinition analyzes the type of the provided value 't' and adds a corresponding Schema to the generator's Schemas map.
 func (g DefinitionGenerator) CreateDefinition(t interface{}) {
 	properties := make(map[string]SchemaProperty)
-	definitionName := fields.RefName(fmt.Sprintf("%T", t), g.HidePackageName)
+	fullName := fmt.Sprintf("%T", t)
+	definitionName := fields.RefName(fullName, g.HidePackageName)
 
 	reflectReturn := reflect.TypeOf(t)
 	switch reflectReturn.Kind() {
@@ -168,6 +190,7 @@ func (g DefinitionGenerator) CreateDefinition(t interface{}) {
 			properties = g.createStructDefinitions(reflectReturn)
 		}
 		definitionName, _ = strings.CutPrefix(definitionName, "[]")
+		fullName, _ = strings.CutPrefix(fullName, "[]")
 	case reflect.Struct:
 		if reflectReturn == reflect.TypeOf(response.CustomResponse{}) {
 			// if CustomResponseType, use Model struct in it
@@ -183,6 +206,7 @@ func (g DefinitionGenerator) CreateDefinition(t interface{}) {
 	// delete empty json tags
 	delete(properties, "")
 
+	g.recordName(definitionName, fullName)
 	g.Schemas[definitionName] = Schema{
 		Type:       "object",
 		Properties: properties,
@@ -359,6 +383,7 @@ func (g DefinitionGenerator) createStructDefinitions(structType reflect.Type) ma
 
 		case "map":
 			name := fmt.Sprintf("%s.%s", fields.RefName(structType.String(), g.HidePackageName), fieldJsonTag)
+			g.recordName(name, fmt.Sprintf("%s.%s", structType.String(), fieldJsonTag))
 			mapKeyType := field.Type.Key()
 			mapValueType := field.Type.Elem()
 			if mapValueType.Kind() == reflect.Ptr {

--- a/v3/docs/05-api-reference.md
+++ b/v3/docs/05-api-reference.md
@@ -143,9 +143,9 @@ type Config struct {
 
 When `HidePackageName` is `true`, schema keys and `$ref` values omit the package
 qualifier — `#/components/schemas/models.MyStruct` becomes `#/components/schemas/MyStruct`.
-It defaults to `false`, preserving the package-qualified names. Enable it only when model
-names are unique across packages, since stripping the package can otherwise cause name
-collisions.
+It defaults to `false`, preserving the package-qualified names. If two types from different
+packages strip to the same name, `ToJson()` returns a `*NameCollisionError` (and `MustToJson()`
+panics) rather than silently overwriting one schema; rename one type or disable the option.
 
 ### `Contact`
 

--- a/v3/generate.go
+++ b/v3/generate.go
@@ -71,14 +71,16 @@ func appendResponses(sourceResponses map[string]endpoint.JsonResponse, additiona
 	return sourceResponses
 }
 
-func (o *OpenAPI) generateOpenAPIJson() {
+func (o *OpenAPI) generateOpenAPIJson() error {
 	if len(o.endpoints) == 0 {
 		log.Println("No endpoints found")
-		return
+		return nil
 	}
 
 	// generate schemas component of OpenAPI json: https://spec.openapis.org/oas/v3.0.3#components-object
-	o.generateOpenAPIDefinition()
+	if err := o.generateOpenAPIDefinition(); err != nil {
+		return err
+	}
 
 	// convert all user EndPoint models to 'paths' fields of OpenAPI json
 	// https://spec.openapis.org/oas/v3.0.3#paths-object
@@ -186,18 +188,25 @@ func (o *OpenAPI) generateOpenAPIJson() {
 		// Update the PathItem in the map
 		o.Paths[path] = pathItem
 	}
+
+	return nil
 }
 
 // ToJson converts the OpenAPI object into its JSON representation formatted as bytes.
 // It returns a slice of bytes containing the OpenAPI documentation in JSON format.
 func (o *OpenAPI) ToJson() (jsonDocs []byte, err error) {
-	o.generateOpenAPIJson()
+	if err := o.generateOpenAPIJson(); err != nil {
+		return nil, err
+	}
 	return json.MarshalIndent(o, "", "  ")
 }
 
 // MustToJson same thing as ToJson except for it doesn't return an error.
+// It panics if a name collision is detected while generating the document.
 func (o OpenAPI) MustToJson() (jsonDocs []byte) {
-	o.generateOpenAPIJson()
+	if err := o.generateOpenAPIJson(); err != nil {
+		panic(err)
+	}
 
 	json, err := json.MarshalIndent(o, "", "  ")
 	if err != nil {
@@ -208,23 +217,28 @@ func (o OpenAPI) MustToJson() (jsonDocs []byte) {
 }
 
 // generate "schemas" keys from endpoints: https://spec.openapis.org/oas/v3.0.3#schema-object
-func (o *OpenAPI) generateOpenAPIDefinition() {
+// It returns a *NameCollisionError when HidePackageName causes two distinct types
+// to map to the same stripped schema name.
+func (o *OpenAPI) generateOpenAPIDefinition() error {
+	// shared across all createDefinition calls so collisions are detected document-wide
+	definitionTypeNames := map[string]map[string]struct{}{}
 	for _, endpoint := range o.endpoints {
 		if endpoint.Body.Content != nil {
-			o.createDefinition(endpoint.Body.Content)
+			o.createDefinition(endpoint.Body.Content, definitionTypeNames)
 		}
-		o.createDefinitions(endpoint.SuccessfulReturns())
-		o.createDefinitions(endpoint.Errors())
+		o.createDefinitions(endpoint.SuccessfulReturns(), definitionTypeNames)
+		o.createDefinitions(endpoint.Errors(), definitionTypeNames)
 	}
+	return collisionError(definitionTypeNames)
 }
 
-func (o *OpenAPI) createDefinitions(r []response.Response) {
+func (o *OpenAPI) createDefinitions(r []response.Response, definitionTypeNames map[string]map[string]struct{}) {
 	for _, obj := range r {
-		o.createDefinition(obj)
+		o.createDefinition(obj, definitionTypeNames)
 	}
 }
 
-func (o *OpenAPI) createDefinition(t interface{}) {
+func (o *OpenAPI) createDefinition(t interface{}, definitionTypeNames map[string]map[string]struct{}) {
 	if o.Components == nil {
 		o.Components = &Components{
 			Schemas: make(map[string]definition.Schema),
@@ -234,7 +248,7 @@ func (o *OpenAPI) createDefinition(t interface{}) {
 		o.Components.Schemas = make(map[string]definition.Schema)
 	}
 
-	generator := definition.NewDefinitionGenerator(o.Components.Schemas, o.hidePackageName)
+	generator := definition.NewDefinitionGenerator(o.Components.Schemas, o.hidePackageName, definitionTypeNames)
 	generator.CreateDefinition(t)
 }
 

--- a/v3/openapi_test.go
+++ b/v3/openapi_test.go
@@ -2,6 +2,7 @@ package swagno3
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/go-swagno/swagno/v3/components/http/response"
 	"github.com/go-swagno/swagno/v3/components/parameter"
 	"github.com/go-swagno/swagno/v3/components/security"
+	"github.com/go-swagno/swagno/v3/example/models"
 )
 
 type TestUser struct {
@@ -338,6 +340,71 @@ func TestHidePackageNameV3(t *testing.T) {
 
 		if !strings.Contains(doc, `"#/components/schemas/swagno3.TestUser"`) {
 			t.Errorf("expected default output to keep package qualifier \"swagno3.TestUser\":\n%s", doc)
+		}
+	})
+}
+
+// SuccessfulResponse is a deliberate name twin of models.SuccessfulResponse, declared
+// in this (swagno3) package, so that enabling HidePackageName makes both strip to the
+// same "SuccessfulResponse" name and triggers a collision.
+type SuccessfulResponse struct {
+	Status string `json:"status"`
+}
+
+// TestHidePackageNameCollisionV3 verifies that when HidePackageName strips two distinct
+// types from different packages to the same name, generation fails with a
+// *NameCollisionError instead of silently dropping one of the schemas.
+func TestHidePackageNameCollisionV3(t *testing.T) {
+	buildColliding := func() []*endpoint.EndPoint {
+		return []*endpoint.EndPoint{
+			endpoint.New(
+				endpoint.GET,
+				"/a",
+				endpoint.WithSuccessfulReturns([]response.Response{response.New(models.SuccessfulResponse{}, "200", "OK")}),
+			),
+			endpoint.New(
+				endpoint.GET,
+				"/b",
+				endpoint.WithSuccessfulReturns([]response.Response{response.New(SuccessfulResponse{}, "200", "OK")}),
+			),
+		}
+	}
+
+	t.Run("ToJson returns NameCollisionError", func(t *testing.T) {
+		openapi := New(Config{Title: "Test API", Version: "v1.0.0", HidePackageName: true})
+		openapi.AddEndpoints(buildColliding())
+
+		_, err := openapi.ToJson()
+		if err == nil {
+			t.Fatal("expected a collision error, got nil")
+		}
+		var collisionErr *NameCollisionError
+		if !errors.As(err, &collisionErr) {
+			t.Fatalf("expected *NameCollisionError, got %T: %v", err, err)
+		}
+		if _, ok := collisionErr.Collisions["SuccessfulResponse"]; !ok {
+			t.Errorf("expected collision on %q, got %v", "SuccessfulResponse", collisionErr.Collisions)
+		}
+	})
+
+	t.Run("MustToJson panics", func(t *testing.T) {
+		openapi := New(Config{Title: "Test API", Version: "v1.0.0", HidePackageName: true})
+		openapi.AddEndpoints(buildColliding())
+
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected MustToJson to panic on collision, but it did not")
+			}
+		}()
+		openapi.MustToJson()
+	})
+
+	t.Run("no collision when HidePackageName is disabled", func(t *testing.T) {
+		openapi := New(Config{Title: "Test API", Version: "v1.0.0"})
+		openapi.AddEndpoints(buildColliding())
+
+		if _, err := openapi.ToJson(); err != nil {
+			t.Fatalf("expected no error with HidePackageName disabled, got %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Error on name collisions when `HidePackageName` is enabled

  Follow-up to #53 (the `HidePackageName` option, issue #49).

  `HidePackageName` strips the package qualifier from model references, so `models.User` becomes `User`. The documented risk is that two distinct types from different packages can collapse to the same short name (e.g. `models.User` and `dto.User` both → `User`). Until now this happened **silently**: the second definition overwrote the first, one schema was lost, and the resulting `$ref`s became ambiguous.

  This PR detects such collisions and **fails fast** instead of producing a broken document.
  Detection is active **only when `HidePackageName == true`**, so default behavior is completely unchanged.

  ### Behavior

  - `ToJson()` returns a `*NameCollisionError` (it already returns `error`, so no signature change).
  - `MustToJson()` panics, consistent with its `Must*` contract.
  - The error names the colliding short name and the conflicting full types, e.g.:

>  swagno: HidePackageName name collision: "User" maps to multiple types [dto.User, models.User]; rename one of the types or set HidePackageName to false

### Usage

  ```go
  sw := swagno.New(swagno.Config{Title: "My API", Version: "v1.0.0", HidePackageName: true})
  // ... endpoints returning models.User and dto.User ...

  _, err := sw.ToJson()
  var collision *swagno.NameCollisionError
  if errors.As(err, &collision) {
      // collision.Collisions == map["User"][]string{"dto.User", "models.User"}
  }
  ```

  The same applies to v3 via `swagno3.NameCollisionError` and `#/components/schemas/...`.

  ### Implementation

  - The definition generator now records, per stripped name, the set of full type names that produced it (only when `HidePackageName` is on). A name produced by more than one distinct type is a collision. Tracking is shared across the whole document, mirrored for v2 and v3.
  - Collision scanning + the typed error live in the new `collision.go` / `v3/collision.go`.

  ### Tests

  - `TestHidePackageNameCollision` (v2) and `TestHidePackageNameCollisionV3` (v3): assert `ToJson` returns `*NameCollisionError`, `MustToJson` panics, and that disabling the option produces no error.
  - Existing `TestHidePackageName` / golden tests pass unchanged (proves no false positives on normal multi-model documents).

  ### Docs

  Updated the collision caveat in `README.md`, `v3/README.md`, and both `05-api-reference.md` files to state that collisions now surface as an error/panic.